### PR TITLE
forward the extra repository and homepage fields, remove some logs

### DIFF
--- a/graphql/queries/publish_package.graphql
+++ b/graphql/queries/publish_package.graphql
@@ -1,4 +1,4 @@
-mutation PublishPackageMutation($name: String!, $version: String!, $description: String!, $manifest: String!, $license: String, $readme: String, $fileName:String) {
+mutation PublishPackageMutation($name: String!, $version: String!, $description: String!, $manifest: String!, $license: String, $readme: String, $fileName:String, $repository:String, $homepage:String) {
   publishPackage(input: {
     name: $name,
     version: $version,
@@ -7,6 +7,8 @@ mutation PublishPackageMutation($name: String!, $version: String!, $description:
     license: $license,
     readme: $readme,
     file: $fileName,
+    repository: $repository,
+    homepage: $homepage,
     clientMutationId: ""
   }) {
     success

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -21,7 +21,6 @@ pub fn publish() -> Result<(), failure::Error> {
     let mut builder = Builder::new(Vec::new());
     let cwd = env::current_dir()?;
     let manifest_path_buf = cwd.join(MANIFEST_FILE_NAME);
-    println!("{}", manifest_path_buf.display());
     let contents =
         fs::read_to_string(&manifest_path_buf).map_err(|_e| PublishError::MissingManifestInCwd)?;
     let manifest: Manifest = toml::from_str(&contents)?;
@@ -30,7 +29,6 @@ pub fn publish() -> Result<(), failure::Error> {
     let package = &manifest.package;
     let modules = manifest.module.as_ref().ok_or(PublishError::NoModule)?;
     let manifest_string = toml::to_string(&manifest)?;
-    println!("{}", manifest_string);
 
     let readme = package.readme.as_ref().and_then(|readme_path| {
         if let Err(_) = builder.append_path(readme_path) {
@@ -65,8 +63,6 @@ pub fn publish() -> Result<(), failure::Error> {
     gz_enc.write_all(&tar_archive_data).unwrap();
     let _compressed_archive = gz_enc.finish().unwrap();
 
-    println!("{}", archive_path.display());
-
     let q = PublishPackageMutation::build_query(publish_package_mutation::Variables {
         name: package.name.to_string(),
         version: package.version.clone(),
@@ -74,6 +70,8 @@ pub fn publish() -> Result<(), failure::Error> {
         manifest: manifest_string,
         license: package.license.clone(),
         readme,
+        repository: package.repository.clone(),
+        homepage: package.homepage.clone(),
         file_name: Some(archive_name.clone()),
     });
     assert!(archive_path.exists());


### PR DESCRIPTION
This PR adds the homepage and the repository field to the publish mutation. Some old debug logs are removed.