### PR TITLE
better error message running unknown command

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -32,7 +32,8 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
     let mut wasmer_extra_flags: Option<Vec<OsString>> = None;
     // hack to get around running commands for local modules
     let source_path: PathBuf = if let Ok(manifest) = Manifest::find_in_directory(&current_dir) {
-        let lockfile_command = lockfile.get_command(command_name)
+        let lockfile_command = lockfile
+            .get_command(command_name)
             .map_err(|_| RunError::CommandNotFound(command_name.to_string()))?;
 
         wasmer_extra_flags = manifest
@@ -64,7 +65,8 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
             PathBuf::from(&lockfile_module.entry)
         }
     } else {
-        let lockfile_command = lockfile.get_command(command_name)
+        let lockfile_command = lockfile
+            .get_command(command_name)
             .map_err(|_| RunError::CommandNotFoundInDependencies(command_name.to_string()))?;
 
         let lockfile_module = lockfile.get_module(
@@ -156,8 +158,14 @@ enum RunError {
     CannotRegenLockfile(String, failure::Error),
     #[fail(display = "Could not find lock file: {}", _0)]
     MissingLockFile(String),
-    #[fail(display = "Command \"{}\" not found in the current package manifest or any of the installed dependencies.", _0)]
+    #[fail(
+        display = "Command \"{}\" not found in the current package manifest or any of the installed dependencies.",
+        _0
+    )]
     CommandNotFound(String),
-    #[fail(display = "Command \"{}\" not found in the installed dependencies.", _0)]
+    #[fail(
+        display = "Command \"{}\" not found in the installed dependencies.",
+        _0
+    )]
     CommandNotFoundInDependencies(String),
 }


### PR DESCRIPTION
This feature adds some better messages when running commands that don't exist. We show a different message based on if we are running with a manifest or not.

![2019-04-16 16 00 13](https://user-images.githubusercontent.com/1364747/56249558-0dbb8c80-6061-11e9-9b8c-72f9fd623151.gif)
