### PR TITLE
Don't generate a lock file without installed dependencies.

### DIFF
--- a/src/dataflow/merged_lockfile_packages.rs
+++ b/src/dataflow/merged_lockfile_packages.rs
@@ -69,11 +69,13 @@ impl<'a> MergedLockfilePackages<'a> {
             }
         }
 
-        let lockfile = Lockfile { modules, commands };
+        if !modules.is_empty() && !commands.is_empty() {
+            let lockfile = Lockfile { modules, commands };
 
-        lockfile
-            .save(directory)
-            .map_err(|e| Error::FailedToSaveLockfile(e.to_string()))?;
+            lockfile
+                .save(directory)
+                .map_err(|e| Error::FailedToSaveLockfile(e.to_string()))?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
If you run `wapm run module` on a directory that doesn't have installed
dependencies, wapm creates an empty lock file. This is poluting the
directory in an error case, and it should probably avoided.