### PR TITLE
Fix/never smart decompress with reqwest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Refactored process for generating updates to manifest, regenerating the lockfile, and installing packages.
-
+### Fixed
+- Fixed installing packages with http responses that are missing the gzip content encoding header.
 
 [Unreleased]: https://github.com/wasmerio/wapm-cli/compare/0.1.0...HEAD
 [0.1.0]: https://github.com/wasmerio/wapm-cli/releases/tag/v0.1.0

--- a/src/dataflow/installed_manifest_packages.rs
+++ b/src/dataflow/installed_manifest_packages.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use tar::Archive;
-use reqwest::Client;
+use reqwest::{Client, ClientBuilder};
 use crate::graphql::VERSION;
 use crate::dataflow::manifest_packages::ManifestResult;
 
@@ -133,7 +133,7 @@ impl<'a> Install<'a> for RegistryInstaller {
             fully_qualified_package_display_name(pkg_name, &key.version);
         let package_dir = create_package_dir(&directory, namespace, &fully_qualified_package_name)
             .map_err(|err| Error::IoErrorCreatingDirectory(key.to_string(), err.to_string()))?;
-        let client = Client::new();
+        let client = ClientBuilder::new().gzip(false).build().unwrap();
         let user_agent = format!(
             "wapm/{} {} {}",
             VERSION,


### PR DESCRIPTION
This PR fixes an issue when the download response is missing the correct content encoding type header. The reqwest library will automatically decompress files that have the gzip encoding. This fix turns that smart feature off. This normalizes behavior and prevents the case of double gzip decoding. 