### PR TITLE
Fixed unused import: `Client` warning in installed_manifest_packages.rs

### DIFF
--- a/src/dataflow/installed_manifest_packages.rs
+++ b/src/dataflow/installed_manifest_packages.rs
@@ -7,7 +7,7 @@ use crate::util::{
     create_package_dir, fully_qualified_package_display_name, get_package_namespace_and_name,
 };
 use flate2::read::GzDecoder;
-use reqwest::{Client, ClientBuilder};
+use reqwest::ClientBuilder;
 use std::fs::OpenOptions;
 use std::io;
 use std::io::SeekFrom;


### PR DESCRIPTION
running `$ cargo build` previously resulted in the following warning:

```
   Compiling wapm-cli v0.1.0 (/Users/andrewnesbitt/code/wapm-cli)
warning: unused import: `Client`
  --> src/dataflow/installed_manifest_packages.rs:10:15
   |
10 | use reqwest::{Client, ClientBuilder};
   |               ^^^^^^
```