### PR TITLE
remove sentry logging on normal error

### DIFF
--- a/src/bin/wapm.rs
+++ b/src/bin/wapm.rs
@@ -97,17 +97,7 @@ fn main() {
         }
     };
     if let Err(e) = result {
-        #[cfg(feature = "telemetry")]
-        {
-            // check if telemetry is enabled
-            if _guard.is_some() {
-                sentry::capture_message(&format!("Error: {}", e), sentry::Level::Error);
-                // manually flush guard because we exit the process below
-                drop(_guard);
-            }
-        }
-
-        eprintln!("Fatal Error: {}", e);
+        eprintln!("Error: {}", e);
         std::process::exit(-1);
     }
 }


### PR DESCRIPTION
drastically reduces the amount of logging done when telemetry is on.