### PR TITLE
global install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Install packages with name and version e.g. `wapm install lua@0.1.2`.
 - Fall back to default for `WASMER_DIR` env var if it doesn't exist
+- Global install packages from the registry with `-g`/`--global` flag.
+  - Packages are installed into `WASMER_DIR/globals`.
+  - Packages are runnable from any directory that does not already have that package installed.
 ### Changed
 - Refactored process for generating updates to manifest, regenerating the lockfile, and installing packages.
 - Changed OpenSSL to statically link for Linux builds (because version 1.1 is not widely deployed yet)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,12 +972,21 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl-src"
+version = "111.2.1+1.1.1b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-src 111.2.1+1.1.1b (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2276,6 +2285,7 @@ dependencies = [
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0d6b781aac4ac1bd6cafe2a2f0ad8c16ae8e1dd5184822a16c50139f8838d9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-src 111.2.1+1.1.1b (registry+https://github.com/rust-lang/crates.io-index)" = "a42e4a28c5a3da4b0df51795aee275b812164c43a690caa871bfa71bf0d52439"
 "checksum openssl-sys 0.9.43 (registry+https://github.com/rust-lang/crates.io-index)" = "33c86834957dd5b915623e94f2f4ab2c70dd8f6b70679824155d5ae21dbd495d"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -91,7 +91,7 @@ pub fn install(options: InstallOpt) -> Result<(), failure::Error> {
         // look in the local directory, or the global install directory
         let install_directory: Cow<Path> = match options.global {
             true => {
-                let folder = Config::get_folder()?;
+                let folder = Config::get_globals_directory()?;
                 Cow::Owned(folder)
             }
             false => Cow::Borrowed(&current_directory),

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -35,6 +35,8 @@ enum InstallError {
         name
     )]
     InvalidPackageIdentifier { name: String },
+    #[fail(display = "Must supply package names to install command when using --global/-g flag.")]
+    MustSupplyPackagesWithGlobalFlag,
 }
 
 #[derive(GraphQLQuery)]
@@ -45,71 +47,87 @@ enum InstallError {
 )]
 struct GetPackageQuery;
 
+mod global_flag {
+    pub const GLOBAL_INSTALL: bool = false;
+    pub const LOCAL_INSTALL: bool = true;
+}
+
+mod package_args {
+    pub const NO_PACKAGES: bool = false;
+    pub const SOME_PACKAGES: bool = true;
+}
+
 pub fn install(options: InstallOpt) -> Result<(), failure::Error> {
     let current_directory = env::current_dir()?;
-    if !options.packages.is_empty() {
-        let mut packages = vec![];
-        for name in options.packages {
-            let name_with_version: Vec<&str> = name.split("@").collect();
+    match (options.global, options.packages.is_empty()) {
+        (global_flag::GLOBAL_INSTALL, package_args::NO_PACKAGES) => { // install all global packages - unacceptable use case
+            return Err(InstallError::MustSupplyPackagesWithGlobalFlag.into());
+        },
+        (global_flag::LOCAL_INSTALL, package_args::NO_PACKAGES) => { // install all packages locally
+            let added_packages = vec![];
+            dataflow::update(added_packages, &current_directory)
+                .map_err(|err| InstallError::FailureInstallingPackages(err))?;
+            println!("Packages installed to wapm_packages!");
+        },
+        (_, package_args::SOME_PACKAGES) => {
+            let mut packages = vec![];
+            for name in options.packages {
+                let name_with_version: Vec<&str> = name.split("@").collect();
 
-            match &name_with_version[..] {
-                [package_name, package_version] => {
-                    packages.push((package_name.to_string(), package_version.to_string()));
-                }
-                [name] => {
+                match &name_with_version[..] {
+                    [package_name, package_version] => {
+                        packages.push((package_name.to_string(), package_version.to_string()));
+                    }
+                        [name] => {
                     let q = GetPackageQuery::build_query(get_package_query::Variables {
-                        name: name.to_string(),
+                    name: name.to_string(),
                     });
                     let response: get_package_query::ResponseData = execute_query(&q)?;
                     let package = response.package.ok_or(InstallError::PackageNotFound {
-                        name: name.to_string(),
+                    name: name.to_string(),
                     })?;
                     let last_version =
-                        package
-                            .last_version
-                            .ok_or(InstallError::NoVersionsAvailable {
-                                name: name.to_string(),
-                            })?;
+                    package
+                    .last_version
+                    .ok_or(InstallError::NoVersionsAvailable {
+                    name: name.to_string(),
+                    })?;
                     let package_name = package.name.clone();
                     let package_version = last_version.version.clone();
                     packages.push((package_name, package_version));
-                }
-                _ => {
-                    return Err(
-                        InstallError::InvalidPackageIdentifier { name: name.clone() }.into(),
-                    );
+                    }
+                    _ => {
+                        return Err(
+                            InstallError::InvalidPackageIdentifier { name: name.clone() }.into(),
+                        );
+                    }
                 }
             }
-        }
 
-        let installed_packages: Vec<(&str, &str)> = packages
-            .iter()
-            .map(|(s1, s2)| (s1.as_str(), s2.as_str()))
-            .collect();
+            let installed_packages: Vec<(&str, &str)> = packages
+                .iter()
+                .map(|(s1, s2)| (s1.as_str(), s2.as_str()))
+                .collect();
 
-        // the install directory will determine which wapm.lock we are updating. For now, we
-        // look in the local directory, or the global install directory
-        let install_directory: Cow<Path> = match options.global {
-            true => {
-                let folder = Config::get_globals_directory()?;
-                Cow::Owned(folder)
+            // the install directory will determine which wapm.lock we are updating. For now, we
+            // look in the local directory, or the global install directory
+            let install_directory: Cow<Path> = match options.global {
+                true => {
+                    let folder = Config::get_globals_directory()?;
+                    Cow::Owned(folder)
+                }
+                false => Cow::Borrowed(&current_directory),
+            };
+
+            dataflow::update(installed_packages, install_directory)
+                .map_err(|err| InstallError::CannotRegenLockFile(err))?;
+
+            if options.global {
+                println!("Global package installed successfully!");
+            } else {
+                println!("Package installed successfully to wapm_packages!");
             }
-            false => Cow::Borrowed(&current_directory),
-        };
-
-        dataflow::update(installed_packages, install_directory)
-            .map_err(|err| InstallError::CannotRegenLockFile(err))?;
-
-        if options.global {
-            println!("Global package installed successfully!");
-        } else {
-            println!("Package installed successfully to wapm_packages!");
-        }
-    } else {
-        let added_packages = vec![];
-        dataflow::update(added_packages, &current_directory)
-            .map_err(|err| InstallError::FailureInstallingPackages(err))?;
-        println!("Packages installed to wapm_packages!");
+        },
     }
     Ok(())
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -60,15 +60,17 @@ mod package_args {
 pub fn install(options: InstallOpt) -> Result<(), failure::Error> {
     let current_directory = env::current_dir()?;
     match (options.global, options.packages.is_empty()) {
-        (global_flag::GLOBAL_INSTALL, package_args::NO_PACKAGES) => { // install all global packages - unacceptable use case
+        (global_flag::GLOBAL_INSTALL, package_args::NO_PACKAGES) => {
+            // install all global packages - unacceptable use case
             return Err(InstallError::MustSupplyPackagesWithGlobalFlag.into());
-        },
-        (global_flag::LOCAL_INSTALL, package_args::NO_PACKAGES) => { // install all packages locally
+        }
+        (global_flag::LOCAL_INSTALL, package_args::NO_PACKAGES) => {
+            // install all packages locally
             let added_packages = vec![];
             dataflow::update(added_packages, &current_directory)
                 .map_err(|err| InstallError::FailureInstallingPackages(err))?;
             println!("Packages installed to wapm_packages!");
-        },
+        }
         (_, package_args::SOME_PACKAGES) => {
             let mut packages = vec![];
             for name in options.packages {
@@ -78,23 +80,23 @@ pub fn install(options: InstallOpt) -> Result<(), failure::Error> {
                     [package_name, package_version] => {
                         packages.push((package_name.to_string(), package_version.to_string()));
                     }
-                        [name] => {
-                    let q = GetPackageQuery::build_query(get_package_query::Variables {
-                    name: name.to_string(),
-                    });
-                    let response: get_package_query::ResponseData = execute_query(&q)?;
-                    let package = response.package.ok_or(InstallError::PackageNotFound {
-                    name: name.to_string(),
-                    })?;
-                    let last_version =
-                    package
-                    .last_version
-                    .ok_or(InstallError::NoVersionsAvailable {
-                    name: name.to_string(),
-                    })?;
-                    let package_name = package.name.clone();
-                    let package_version = last_version.version.clone();
-                    packages.push((package_name, package_version));
+                    [name] => {
+                        let q = GetPackageQuery::build_query(get_package_query::Variables {
+                            name: name.to_string(),
+                        });
+                        let response: get_package_query::ResponseData = execute_query(&q)?;
+                        let package = response.package.ok_or(InstallError::PackageNotFound {
+                            name: name.to_string(),
+                        })?;
+                        let last_version =
+                            package
+                                .last_version
+                                .ok_or(InstallError::NoVersionsAvailable {
+                                    name: name.to_string(),
+                                })?;
+                        let package_name = package.name.clone();
+                        let package_version = last_version.version.clone();
+                        packages.push((package_name, package_version));
                     }
                     _ => {
                         return Err(
@@ -127,7 +129,7 @@ pub fn install(options: InstallOpt) -> Result<(), failure::Error> {
             } else {
                 println!("Package installed successfully to wapm_packages!");
             }
-        },
+        }
     }
     Ok(())
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -26,7 +26,9 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
     let (source_path_buf, _command_args, module_name, is_global) =
         get_command_from_anywhere(command_name)?;
 
-    let wasmer_extra_flags: Option<Vec<OsString>> =
+    // do not run with wasmer options if running a global command
+    // this will change in the future.
+    let wasmer_extra_flags: Option<Vec<OsString>> = if !is_global {
         match ManifestResult::find_in_directory(&current_dir) {
             ManifestResult::Manifest(manifest) => {
                 manifest
@@ -41,7 +43,12 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
                     })
             }
             _ => None,
-        };
+        }
+    }
+    else {
+        None
+    };
+
 
     let run_dir = if is_global {
         Config::get_globals_directory().unwrap()

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -42,7 +42,7 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
     };
 
     let run_dir = if is_global {
-        Config::get_folder().unwrap()
+        Config::get_globals_directory().unwrap()
     }
     else {
         current_dir

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -6,6 +6,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use structopt::StructOpt;
+use crate::dataflow::find_command_result;
 
 #[derive(StructOpt, Debug)]
 pub struct RunOpt {
@@ -23,7 +24,7 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
     let command_name = run_options.command.as_str();
     let args = &run_options.args;
     let current_dir = env::current_dir()?;
-    let (source_path_buf, _command_args, module_name, is_global) =
+    let find_command_result::Command { source: source_path_buf, args: _, module_name, is_global } =
         get_command_from_anywhere(command_name)?;
 
     // do not run with wasmer options if running a global command

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -144,28 +144,9 @@ mod test {
 
 #[derive(Debug, Fail)]
 enum RunError {
-    //    #[fail(display = "Failed to run command \"{}\". {}", _0, _1)]
-    //    CannotRegenLockfile(String, dataflow::Error),
-    //    #[fail(display = "Could not find lock file: {}", _0)]
-    //    MissingLockFile(String),
-    //    #[fail(
-    //        display = "Command \"{}\" not found in the current package manifest or any of the installed dependencies.",
-    //        _0
-    //    )]
-    //    CommandNotFound(String),
-    //    #[fail(
-    //        display = "Command \"{}\" not found in the installed dependencies.",
-    //        _0
-    //    )]
-    //    CommandNotFoundInDependencies(String),
     #[fail(
         display = "The command \"{}\" for module \"{}\" is defined but the source at \"{}\" does not exist.",
         _0, _1, _2
     )]
     SourceForCommandNotFound(String, String, String),
-    //    #[fail(
-    //        display = "Command \"{}\" was found in the lockfile but the module \"{}\" from package \"{}\" was not found in the lockfile. Did you modify the lockfile?",
-    //        _0, _1, _2
-    //    )]
-    //    FoundCommandInLockfileButMissingModule(String, String, String),
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,12 +1,11 @@
-use crate::data::lock::is_lockfile_out_of_date;
-use crate::data::manifest::Manifest;
-use crate::dataflow;
-use crate::dataflow::lockfile_packages::LockfileResult;
+use crate::dataflow::find_command_result::get_command_from_anywhere;
 use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use structopt::StructOpt;
+use crate::dataflow::manifest_packages::ManifestResult;
+use crate::config::Config;
 
 #[derive(StructOpt, Debug)]
 pub struct RunOpt {
@@ -24,93 +23,36 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
     let command_name = run_options.command.as_str();
     let args = &run_options.args;
     let current_dir = env::current_dir()?;
-    // regenerate the lockfile if it is out of date
-    match is_lockfile_out_of_date(&current_dir) {
-        Ok(false) => {}
-        _ => dataflow::update(vec![], &current_dir)
-            .map_err(|e| RunError::CannotRegenLockfile(command_name.to_string(), e))?,
-    }
-    let lockfile_result = LockfileResult::find_in_directory(&current_dir);
-    let lockfile = match lockfile_result {
-        LockfileResult::NoLockfile => {
-            return Err(RunError::MissingLockFile("Lockfile was not generated.".to_string()).into())
-        }
-        LockfileResult::LockfileError(e) => {
-            return Err(RunError::MissingLockFile(format!(
-                "There was an issue opening the lockfile. {}",
-                e.to_string()
-            ))
-            .into())
-        }
-        LockfileResult::Lockfile(lockfile) => lockfile,
-    };
+    let (source_path_buf, _command_args, module_name, is_global) = get_command_from_anywhere(command_name)?;
 
-    let mut wasmer_extra_flags: Option<Vec<OsString>> = None;
-    let manifest_result = Manifest::find_in_directory(&current_dir);
-    // hack to get around running commands for local modules
-    let (module_name, source_path): (String, String) = if let Ok(ref manifest) = manifest_result {
-        let lockfile_command = lockfile
-            .get_command(command_name)
-            .map_err(|_| RunError::CommandNotFound(command_name.to_string()))?;
-
-        wasmer_extra_flags = manifest
-            .package
-            .wasmer_extra_flags
-            .clone()
-            .map(|extra_flags| {
-                extra_flags
-                    .split_whitespace()
-                    .map(|str| OsString::from(str))
-                    .collect()
-            });
-
-        if lockfile_command.package_name == manifest.package.name {
-            // this is a local module command
-            let module = manifest.module.as_ref().map(|modules| {
-                let module = modules.iter().find(|m| m.name == lockfile_command.module);
-                module
-            });
-            module
-                .unwrap_or(None)
-                .map(|module| {
-                    (
-                        module.name.clone(),
-                        module.source.clone().to_string_lossy().to_string(),
-                    )
+    let wasmer_extra_flags: Option<Vec<OsString>> = match ManifestResult::find_in_directory(&current_dir) {
+        ManifestResult::Manifest(manifest) => {
+            manifest
+                .package
+                .wasmer_extra_flags
+                .clone()
+                .map(|extra_flags| {
+                    extra_flags
+                        .split_whitespace()
+                        .map(|str| OsString::from(str))
+                        .collect()
                 })
-                .ok_or(RunError::FoundCommandInLockfileButMissingModule(
-                    command_name.to_string(),
-                    lockfile_command.module.to_string(),
-                    lockfile_command.package_name.to_string(),
-                ))?
-        } else {
-            let lockfile_module = lockfile.get_module(
-                &lockfile_command.package_name,
-                &lockfile_command.package_version,
-                &lockfile_command.module,
-            )?;
-            (lockfile_module.name.clone(), lockfile_module.entry.clone())
         }
-    } else {
-        let lockfile_command = lockfile
-            .get_command(command_name)
-            .map_err(|_| RunError::CommandNotFoundInDependencies(command_name.to_string()))?;
-
-        let lockfile_module = lockfile.get_module(
-            &lockfile_command.package_name,
-            &lockfile_command.package_version,
-            &lockfile_command.module,
-        )?;
-        (lockfile_module.name.clone(), lockfile_module.entry.clone())
+        _ => None,
     };
 
-    // check that the source exists
-    let source_path_buf = PathBuf::from(&source_path);
-    source_path_buf.metadata().map_err(|_| {
+    let run_dir = if is_global {
+        Config::get_folder().unwrap()
+    }
+    else {
+        current_dir
+    };
+
+    run_dir.join(&source_path_buf).metadata().map_err(|_| {
         RunError::SourceForCommandNotFound(
             command_name.to_string(),
             module_name.to_string(),
-            source_path.to_string(),
+            source_path_buf.to_string_lossy().to_string(),
         )
     })?;
 
@@ -124,8 +66,8 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
         args,
         wasmer_extra_flags,
         wasi_preopened_dir_flags,
-        &current_dir,
-        source_path,
+        &run_dir,
+        source_path_buf,
         Some(format!("wapm run {}", command_name)),
     )?;
     let mut child = Command::new("wasmer").args(&command_vec).spawn()?;
@@ -201,28 +143,28 @@ mod test {
 
 #[derive(Debug, Fail)]
 enum RunError {
-    #[fail(display = "Failed to run command \"{}\". {}", _0, _1)]
-    CannotRegenLockfile(String, dataflow::Error),
-    #[fail(display = "Could not find lock file: {}", _0)]
-    MissingLockFile(String),
-    #[fail(
-        display = "Command \"{}\" not found in the current package manifest or any of the installed dependencies.",
-        _0
-    )]
-    CommandNotFound(String),
-    #[fail(
-        display = "Command \"{}\" not found in the installed dependencies.",
-        _0
-    )]
-    CommandNotFoundInDependencies(String),
+//    #[fail(display = "Failed to run command \"{}\". {}", _0, _1)]
+//    CannotRegenLockfile(String, dataflow::Error),
+//    #[fail(display = "Could not find lock file: {}", _0)]
+//    MissingLockFile(String),
+//    #[fail(
+//        display = "Command \"{}\" not found in the current package manifest or any of the installed dependencies.",
+//        _0
+//    )]
+//    CommandNotFound(String),
+//    #[fail(
+//        display = "Command \"{}\" not found in the installed dependencies.",
+//        _0
+//    )]
+//    CommandNotFoundInDependencies(String),
     #[fail(
         display = "The command \"{}\" for module \"{}\" is defined but the source at \"{}\" does not exist.",
         _0, _1, _2
     )]
     SourceForCommandNotFound(String, String, String),
-    #[fail(
-        display = "Command \"{}\" was found in the lockfile but the module \"{}\" from package \"{}\" was not found in the lockfile. Did you modify the lockfile?",
-        _0, _1, _2
-    )]
-    FoundCommandInLockfileButMissingModule(String, String, String),
+//    #[fail(
+//        display = "Command \"{}\" was found in the lockfile but the module \"{}\" from package \"{}\" was not found in the lockfile. Did you modify the lockfile?",
+//        _0, _1, _2
+//    )]
+//    FoundCommandInLockfileButMissingModule(String, String, String),
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,11 +1,11 @@
+use crate::config::Config;
 use crate::dataflow::find_command_result::get_command_from_anywhere;
+use crate::dataflow::manifest_packages::ManifestResult;
 use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use structopt::StructOpt;
-use crate::dataflow::manifest_packages::ManifestResult;
-use crate::config::Config;
 
 #[derive(StructOpt, Debug)]
 pub struct RunOpt {
@@ -23,28 +23,29 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
     let command_name = run_options.command.as_str();
     let args = &run_options.args;
     let current_dir = env::current_dir()?;
-    let (source_path_buf, _command_args, module_name, is_global) = get_command_from_anywhere(command_name)?;
+    let (source_path_buf, _command_args, module_name, is_global) =
+        get_command_from_anywhere(command_name)?;
 
-    let wasmer_extra_flags: Option<Vec<OsString>> = match ManifestResult::find_in_directory(&current_dir) {
-        ManifestResult::Manifest(manifest) => {
-            manifest
-                .package
-                .wasmer_extra_flags
-                .clone()
-                .map(|extra_flags| {
-                    extra_flags
-                        .split_whitespace()
-                        .map(|str| OsString::from(str))
-                        .collect()
-                })
-        }
-        _ => None,
-    };
+    let wasmer_extra_flags: Option<Vec<OsString>> =
+        match ManifestResult::find_in_directory(&current_dir) {
+            ManifestResult::Manifest(manifest) => {
+                manifest
+                    .package
+                    .wasmer_extra_flags
+                    .clone()
+                    .map(|extra_flags| {
+                        extra_flags
+                            .split_whitespace()
+                            .map(|str| OsString::from(str))
+                            .collect()
+                    })
+            }
+            _ => None,
+        };
 
     let run_dir = if is_global {
         Config::get_globals_directory().unwrap()
-    }
-    else {
+    } else {
         current_dir
     };
 
@@ -143,28 +144,28 @@ mod test {
 
 #[derive(Debug, Fail)]
 enum RunError {
-//    #[fail(display = "Failed to run command \"{}\". {}", _0, _1)]
-//    CannotRegenLockfile(String, dataflow::Error),
-//    #[fail(display = "Could not find lock file: {}", _0)]
-//    MissingLockFile(String),
-//    #[fail(
-//        display = "Command \"{}\" not found in the current package manifest or any of the installed dependencies.",
-//        _0
-//    )]
-//    CommandNotFound(String),
-//    #[fail(
-//        display = "Command \"{}\" not found in the installed dependencies.",
-//        _0
-//    )]
-//    CommandNotFoundInDependencies(String),
+    //    #[fail(display = "Failed to run command \"{}\". {}", _0, _1)]
+    //    CannotRegenLockfile(String, dataflow::Error),
+    //    #[fail(display = "Could not find lock file: {}", _0)]
+    //    MissingLockFile(String),
+    //    #[fail(
+    //        display = "Command \"{}\" not found in the current package manifest or any of the installed dependencies.",
+    //        _0
+    //    )]
+    //    CommandNotFound(String),
+    //    #[fail(
+    //        display = "Command \"{}\" not found in the installed dependencies.",
+    //        _0
+    //    )]
+    //    CommandNotFoundInDependencies(String),
     #[fail(
         display = "The command \"{}\" for module \"{}\" is defined but the source at \"{}\" does not exist.",
         _0, _1, _2
     )]
     SourceForCommandNotFound(String, String, String),
-//    #[fail(
-//        display = "Command \"{}\" was found in the lockfile but the module \"{}\" from package \"{}\" was not found in the lockfile. Did you modify the lockfile?",
-//        _0, _1, _2
-//    )]
-//    FoundCommandInLockfileButMissingModule(String, String, String),
+    //    #[fail(
+    //        display = "Command \"{}\" was found in the lockfile but the module \"{}\" from package \"{}\" was not found in the lockfile. Did you modify the lockfile?",
+    //        _0, _1, _2
+    //    )]
+    //    FoundCommandInLockfileButMissingModule(String, String, String),
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -28,10 +28,10 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
 
     // do not run with wasmer options if running a global command
     // this will change in the future.
-    let wasmer_extra_flags: Option<Vec<OsString>> = if !is_global {
-        match ManifestResult::find_in_directory(&current_dir) {
-            ManifestResult::Manifest(manifest) => {
-                manifest
+    let wasmer_extra_flags: Option<Vec<OsString>> =
+        if !is_global {
+            match ManifestResult::find_in_directory(&current_dir) {
+                ManifestResult::Manifest(manifest) => manifest
                     .package
                     .wasmer_extra_flags
                     .clone()
@@ -40,15 +40,12 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
                             .split_whitespace()
                             .map(|str| OsString::from(str))
                             .collect()
-                    })
+                    }),
+                _ => None,
             }
-            _ => None,
-        }
-    }
-    else {
-        None
-    };
-
+        } else {
+            None
+        };
 
     let run_dir = if is_global {
         Config::get_globals_directory().unwrap()

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,10 @@ impl Config {
         }
     }
 
+    pub fn get_globals_directory() -> Result<PathBuf, GlobalConfigError> {
+        Self::get_folder().map(|p| p.join("globals"))
+    }
+
     pub fn save(self: &Self) -> Result<(), failure::Error> {
         let path = Self::get_file_location()?;
         let config_serialized = toml::to_string(&self)?;

--- a/src/data/lock/lockfile_module.rs
+++ b/src/data/lock/lockfile_module.rs
@@ -39,4 +39,16 @@ impl LockfileModule {
         };
         lockfile_module
     }
+
+    pub fn from_local_module(name: &str, version: &str, module: &Module) -> Self {
+        LockfileModule {
+            name: module.name.clone(),
+            package_version: version.to_string(),
+            package_name: name.to_string(),
+            source: "local".to_string(),
+            resolved: "local".to_string(),
+            abi: module.abi.clone(),
+            entry: module.source.to_string_lossy().to_string(),
+        }
+    }
 }

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -28,6 +28,11 @@ pub enum Error {
         _0, _1
     )]
     CommandFoundButCorrespondingModuleIsMissing(String, String),
+    #[fail(
+        display = "Failed to get command \"{}\" because there was an error opening the global installation directory. {}",
+        _0, _1
+    )]
+    CouldNotOpenGlobalsDirectory(String, String),
 }
 
 pub enum FindCommandResult {
@@ -159,7 +164,9 @@ pub fn get_command_from_anywhere<S: AsRef<str>>(
     };
 
     // look in the global directory
-    let global_directory = Config::get_globals_directory().unwrap();
+    let global_directory = Config::get_globals_directory().map_err(|e| {
+        Error::CouldNotOpenGlobalsDirectory(command_name.as_ref().to_string(), e.to_string())
+    });
     let global_command_result =
         FindCommandResult::find_command_in_directory(&global_directory, &command_name);
 

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -53,8 +53,7 @@ impl FindCommandResult {
                 if lockfile_command.package_name == manifest.package.name {
                     // this is a local module command
                     let module = manifest.module.as_ref().map(|modules| {
-                        let module = modules.iter().find(|m| m.name == lockfile_command.module);
-                        module
+                        modules.iter().find(|m| m.name == lockfile_command.module)
                     });
                     match module.unwrap_or(None) {
                         Some(module) => FindCommandResult::CommandFound(

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -1,0 +1,176 @@
+use crate::config::Config;
+use crate::data::lock::lockfile::Lockfile;
+use crate::data::manifest::Manifest;
+use crate::dataflow::lockfile_packages::LockfileResult;
+use crate::dataflow::manifest_packages::ManifestResult;
+use std::env;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, Fail)]
+pub enum Error {
+    #[fail(
+        display = "Command \"{}\" was not found in the local directory or the global install directory",
+        _0
+    )]
+    CommandNotFound(String),
+    #[fail(
+        display = "Command \"{}\" was not found in the local directory. There was an error parsing the global lockfile. {}",
+        _0, _1
+    )]
+    CommandNotFoundInLocalDirectoryAndErrorReadingGlobalDirectory(String, String),
+    #[fail(
+        display = "Could not find command \"{}\" because there was a problem with the global directory. {}",
+        _0, _1
+    )]
+    ErrorReadingLocalDirectory(String, String),
+    #[fail(
+        display = "Command \"{}\" exists in lockfile, but corresponding module \"{}\" not found in lockfile.",
+        _0, _1
+    )]
+    CommandFoundButCorrespondingModuleIsMissing(String, String),
+}
+
+pub enum FindCommandResult {
+    CommandNotFound(String),
+    CommandFound(PathBuf, Option<String>, String), // source, args, module name
+    Error(failure::Error),
+}
+
+impl FindCommandResult {
+    fn find_command_in_manifest_and_lockfile<S: AsRef<str>>(
+        command_name: S,
+        manifest: Manifest,
+        lockfile: Lockfile,
+    ) -> Self {
+        match lockfile.get_command(command_name.as_ref()) {
+            Ok(lockfile_command) => {
+                if lockfile_command.package_name == manifest.package.name {
+                    // this is a local module command
+                    let module = manifest.module.as_ref().map(|modules| {
+                        let module = modules.iter().find(|m| m.name == lockfile_command.module);
+                        module
+                    });
+                    match module.unwrap_or(None) {
+                        Some(module) => FindCommandResult::CommandFound(
+                            module.source.clone(),
+                            lockfile_command.main_args.clone(),
+                            module.name.clone(),
+                        ),
+                        None => FindCommandResult::Error(
+                            Error::CommandFoundButCorrespondingModuleIsMissing(
+                                command_name.as_ref().to_string(),
+                                lockfile_command.module.clone(),
+                            )
+                            .into(),
+                        ),
+                    }
+                } else {
+                    match lockfile.get_module(
+                        &lockfile_command.package_name,
+                        &lockfile_command.package_version,
+                        &lockfile_command.module,
+                    ) {
+                        Ok(lockfile_module) => {
+                            let path = PathBuf::from(&lockfile_module.entry);
+                            FindCommandResult::CommandFound(
+                                path,
+                                lockfile_command.main_args.clone(),
+                                lockfile_module.name.clone()
+                            )
+                        }
+                        Err(e) => FindCommandResult::Error(e),
+                    }
+                }
+            }
+            Err(e) => FindCommandResult::Error(e),
+        }
+    }
+
+    fn find_command_in_lockfile<S: AsRef<str>>(command_name: S, lockfile: Lockfile) -> Self {
+        match lockfile.get_command(command_name.as_ref()) {
+            Ok(lockfile_command) => {
+                match lockfile.get_module(
+                    &lockfile_command.package_name,
+                    &lockfile_command.package_version,
+                    &lockfile_command.module,
+                ) {
+                    Ok(lockfile_module) => {
+                        let path = PathBuf::from(&lockfile_module.entry);
+                        FindCommandResult::CommandFound(path, lockfile_command.main_args.clone(), lockfile_module.name.clone())
+                    }
+                    Err(_e) => FindCommandResult::CommandNotFound(command_name.as_ref().to_string()),
+                }
+            }
+            Err(_e) => FindCommandResult::CommandNotFound(command_name.as_ref().to_string()),
+        }
+    }
+
+    pub fn find_command_in_directory<P: AsRef<Path>, S: AsRef<str>>(
+        directory: P,
+        command_name: S,
+    ) -> Self {
+        let manifest_result = ManifestResult::find_in_directory(&directory);
+        let lockfile_result = LockfileResult::find_in_directory(&directory);
+        match (manifest_result, lockfile_result) {
+            (ManifestResult::ManifestError(e), _) => return FindCommandResult::Error(e.into()),
+            (_, LockfileResult::LockfileError(e)) => return FindCommandResult::Error(e.into()),
+            (ManifestResult::NoManifest, LockfileResult::NoLockfile) => {} // continue
+            (ManifestResult::NoManifest, LockfileResult::Lockfile(l)) => {
+                return Self::find_command_in_lockfile(command_name, l)
+            }
+            (ManifestResult::Manifest(_m), LockfileResult::NoLockfile) => {
+                panic!("Manifest exists, but lockfile not found!")
+            }
+            (ManifestResult::Manifest(m), LockfileResult::Lockfile(l)) => {
+                return Self::find_command_in_manifest_and_lockfile(command_name, m, l);
+            }
+        };
+        FindCommandResult::CommandNotFound(command_name.as_ref().to_string())
+    }
+}
+
+/// Get a command from anywhere, where anywhere is the set of packages in the local lockfile and the global lockfile.
+/// A flag indicating global run is also returned. Commands are found in local lockfile first.
+pub fn get_command_from_anywhere<S: AsRef<str>>(
+    command_name: S,
+) -> Result<(PathBuf, Option<String>, String, bool), Error> {
+    // look in the local directory, update if necessary
+    let current_directory = env::current_dir().unwrap();
+    let local_command_result =
+        FindCommandResult::find_command_in_directory(&current_directory, &command_name);
+
+    match local_command_result {
+        FindCommandResult::CommandNotFound(_cmd) => {} // continue
+        FindCommandResult::CommandFound(path, args, module_name) => {
+            return Ok((path, args, module_name, false));
+        }
+        FindCommandResult::Error(e) => {
+            return Err(Error::ErrorReadingLocalDirectory(
+                command_name.as_ref().to_string(),
+                e.to_string(),
+            ))
+        }
+    };
+
+    // look in the global directory
+    let global_directory = Config::get_folder().unwrap();
+    let global_command_result =
+        FindCommandResult::find_command_in_directory(&global_directory, &command_name);
+
+    match global_command_result {
+        FindCommandResult::CommandNotFound(_) => {} // continue
+        FindCommandResult::CommandFound(path, args, module_name) => {
+            return Ok((path, args, module_name, true));
+        }
+        FindCommandResult::Error(e) => {
+            return Err(
+                Error::CommandNotFoundInLocalDirectoryAndErrorReadingGlobalDirectory(
+                    command_name.as_ref().to_string(),
+                    e.to_string(),
+                ),
+            )
+        }
+    };
+
+    return Err(Error::CommandNotFound(command_name.as_ref().to_string()));
+}

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -145,11 +145,19 @@ impl FindCommandResult {
     }
 }
 
+pub struct Command {
+// PathBuf, Option<String>, String, bool
+    pub source: PathBuf,
+    pub args: Option<String>,
+    pub module_name: String,
+    pub is_global: bool,
+}
+
 /// Get a command from anywhere, where anywhere is the set of packages in the local lockfile and the global lockfile.
 /// A flag indicating global run is also returned. Commands are found in local lockfile first.
 pub fn get_command_from_anywhere<S: AsRef<str>>(
     command_name: S,
-) -> Result<(PathBuf, Option<String>, String, bool), Error> {
+) -> Result<Command, Error> {
     // look in the local directory, update if necessary
     let current_directory = env::current_dir().unwrap();
     let local_command_result =
@@ -158,7 +166,7 @@ pub fn get_command_from_anywhere<S: AsRef<str>>(
     match local_command_result {
         FindCommandResult::CommandNotFound(_cmd) => {} // continue
         FindCommandResult::CommandFound(path, args, module_name) => {
-            return Ok((path, args, module_name, false));
+            return Ok(Command {source: path, args, module_name, is_global: false });
         }
         FindCommandResult::Error(e) => {
             return Err(Error::ErrorReadingLocalDirectory(
@@ -178,7 +186,7 @@ pub fn get_command_from_anywhere<S: AsRef<str>>(
     match global_command_result {
         FindCommandResult::CommandNotFound(_) => {} // continue
         FindCommandResult::CommandFound(path, args, module_name) => {
-            return Ok((path, args, module_name, true));
+            return Ok(Command {source: path, args, module_name, is_global: true });
         }
         FindCommandResult::Error(e) => {
             return Err(

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -52,10 +52,12 @@ impl FindCommandResult {
             Ok(lockfile_command) => {
                 if lockfile_command.package_name == manifest.package.name {
                     // this is a local module command
-                    let module = manifest.module.as_ref().map(|modules| {
-                        modules.iter().find(|m| m.name == lockfile_command.module)
-                    });
-                    match module.unwrap_or(None) {
+                    let found_module = manifest
+                        .module
+                        .as_ref()
+                        .and_then(|modules| modules.iter().find(|m| m.name == lockfile_command.module));
+                    match found_module
+                    {
                         Some(module) => FindCommandResult::CommandFound(
                             module.source.clone(),
                             lockfile_command.main_args.clone(),

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 #[derive(Clone, Debug, Fail)]
 pub enum Error {
     #[fail(
-        display = "Command \"{}\" was not found in the local directory or the global install directory",
+        display = "Command \"{}\" was not found in the local directory or the global install directory.",
         _0
     )]
     CommandNotFound(String),
@@ -75,7 +75,7 @@ impl FindCommandResult {
                             FindCommandResult::CommandFound(
                                 path,
                                 lockfile_command.main_args.clone(),
-                                lockfile_module.name.clone()
+                                lockfile_module.name.clone(),
                             )
                         }
                         Err(e) => FindCommandResult::Error(e),
@@ -96,9 +96,15 @@ impl FindCommandResult {
                 ) {
                     Ok(lockfile_module) => {
                         let path = PathBuf::from(&lockfile_module.entry);
-                        FindCommandResult::CommandFound(path, lockfile_command.main_args.clone(), lockfile_module.name.clone())
+                        FindCommandResult::CommandFound(
+                            path,
+                            lockfile_command.main_args.clone(),
+                            lockfile_module.name.clone(),
+                        )
                     }
-                    Err(_e) => FindCommandResult::CommandNotFound(command_name.as_ref().to_string()),
+                    Err(_e) => {
+                        FindCommandResult::CommandNotFound(command_name.as_ref().to_string())
+                    }
                 }
             }
             Err(_e) => FindCommandResult::CommandNotFound(command_name.as_ref().to_string()),

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -52,12 +52,10 @@ impl FindCommandResult {
             Ok(lockfile_command) => {
                 if lockfile_command.package_name == manifest.package.name {
                     // this is a local module command
-                    let found_module = manifest
-                        .module
-                        .as_ref()
-                        .and_then(|modules| modules.iter().find(|m| m.name == lockfile_command.module));
-                    match found_module
-                    {
+                    let found_module = manifest.module.as_ref().and_then(|modules| {
+                        modules.iter().find(|m| m.name == lockfile_command.module)
+                    });
+                    match found_module {
                         Some(module) => FindCommandResult::CommandFound(
                             module.source.clone(),
                             lockfile_command.main_args.clone(),
@@ -146,7 +144,7 @@ impl FindCommandResult {
 }
 
 pub struct Command {
-// PathBuf, Option<String>, String, bool
+    // PathBuf, Option<String>, String, bool
     pub source: PathBuf,
     pub args: Option<String>,
     pub module_name: String,
@@ -155,9 +153,7 @@ pub struct Command {
 
 /// Get a command from anywhere, where anywhere is the set of packages in the local lockfile and the global lockfile.
 /// A flag indicating global run is also returned. Commands are found in local lockfile first.
-pub fn get_command_from_anywhere<S: AsRef<str>>(
-    command_name: S,
-) -> Result<Command, Error> {
+pub fn get_command_from_anywhere<S: AsRef<str>>(command_name: S) -> Result<Command, Error> {
     // look in the local directory, update if necessary
     let current_directory = env::current_dir().unwrap();
     let local_command_result =
@@ -166,7 +162,12 @@ pub fn get_command_from_anywhere<S: AsRef<str>>(
     match local_command_result {
         FindCommandResult::CommandNotFound(_cmd) => {} // continue
         FindCommandResult::CommandFound(path, args, module_name) => {
-            return Ok(Command {source: path, args, module_name, is_global: false });
+            return Ok(Command {
+                source: path,
+                args,
+                module_name,
+                is_global: false,
+            });
         }
         FindCommandResult::Error(e) => {
             return Err(Error::ErrorReadingLocalDirectory(
@@ -186,7 +187,12 @@ pub fn get_command_from_anywhere<S: AsRef<str>>(
     match global_command_result {
         FindCommandResult::CommandNotFound(_) => {} // continue
         FindCommandResult::CommandFound(path, args, module_name) => {
-            return Ok(Command {source: path, args, module_name, is_global: true });
+            return Ok(Command {
+                source: path,
+                args,
+                module_name,
+                is_global: true,
+            });
         }
         FindCommandResult::Error(e) => {
             return Err(

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -89,7 +89,6 @@ impl FindCommandResult {
                     }
                 }
             }
-
         }
     }
 
@@ -131,6 +130,10 @@ impl FindCommandResult {
             (ManifestResult::NoManifest, LockfileResult::Lockfile(l)) => {
                 return Self::find_command_in_lockfile(command_name, l)
             }
+            // the edge case of a manifest, but no lockfile would an invalid state. This function
+            // should always be run after updating the lockfile with the latest manifest changes.
+            // If that function were to fail so horribly that it did not error, and no lockfile was
+            // generated, then we will get this panic.
             (ManifestResult::Manifest(_m), LockfileResult::NoLockfile) => {
                 panic!("Manifest exists, but lockfile not found!")
             }

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -166,7 +166,7 @@ pub fn get_command_from_anywhere<S: AsRef<str>>(
     // look in the global directory
     let global_directory = Config::get_globals_directory().map_err(|e| {
         Error::CouldNotOpenGlobalsDirectory(command_name.as_ref().to_string(), e.to_string())
-    });
+    })?;
     let global_command_result =
         FindCommandResult::find_command_in_directory(&global_directory, &command_name);
 

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -153,7 +153,7 @@ pub fn get_command_from_anywhere<S: AsRef<str>>(
     };
 
     // look in the global directory
-    let global_directory = Config::get_folder().unwrap();
+    let global_directory = Config::get_globals_directory().unwrap();
     let global_command_result =
         FindCommandResult::find_command_in_directory(&global_directory, &command_name);
 

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -48,6 +48,7 @@ impl FindCommandResult {
         lockfile: Lockfile,
     ) -> Self {
         match lockfile.get_command(command_name.as_ref()) {
+            Err(e) => FindCommandResult::Error(e),
             Ok(lockfile_command) => {
                 if lockfile_command.package_name == manifest.package.name {
                     // this is a local module command
@@ -87,7 +88,7 @@ impl FindCommandResult {
                     }
                 }
             }
-            Err(e) => FindCommandResult::Error(e),
+
         }
     }
 

--- a/src/dataflow/local_package.rs
+++ b/src/dataflow/local_package.rs
@@ -1,0 +1,45 @@
+use crate::data::lock::lockfile_command::LockfileCommand;
+use crate::data::lock::lockfile_module::LockfileModule;
+use crate::data::manifest::Manifest;
+use crate::dataflow::lockfile_packages::{LockfilePackage, LockfilePackages};
+use crate::dataflow::PackageKey;
+use std::collections::hash_map::HashMap;
+
+pub struct LocalPackage<'a> {
+    pub key: PackageKey<'a>,
+    pub data: LockfilePackage,
+}
+
+impl<'a> LocalPackage<'a> {
+    pub fn new_from_local_package_in_manifest(manifest: &'a Manifest) -> Self {
+        let package_name = manifest.package.name.as_str();
+        let package_version = manifest.package.name.as_str();
+        let modules = manifest
+            .module
+            .as_ref()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|m| LockfileModule::from_local_module(package_name, package_version, &m))
+            .collect();
+        let commands = manifest
+            .command
+            .as_ref()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|c| LockfileCommand::from_command(package_name, package_version, &c))
+            .collect();
+        let key = PackageKey::new_registry_package(package_name, package_version);
+        let data = LockfilePackage { modules, commands };
+        LocalPackage { key, data }
+    }
+}
+
+impl<'a> Into<LockfilePackages<'a>> for LocalPackage<'a> {
+    fn into(self) -> LockfilePackages<'a> {
+        let mut packages = HashMap::new();
+        packages.insert(self.key, self.data);
+        LockfilePackages { packages }
+    }
+}

--- a/src/dataflow/lockfile_packages.rs
+++ b/src/dataflow/lockfile_packages.rs
@@ -162,14 +162,13 @@ impl<'a> LockfilePackages<'a> {
         self.packages.keys().cloned().collect()
     }
 
-    pub fn find_missing_packages(&self) -> HashSet<PackageKey<'a>> {
-        use std::path::PathBuf;
+    pub fn find_missing_packages<P: AsRef<Path>>(&self, directory: P) -> HashSet<PackageKey<'a>> {
         let missing_packages: HashSet<PackageKey<'a>> = self
             .packages
             .iter()
             .filter_map(|(key, data)| {
                 if data.modules.iter().any(|module| {
-                    let path = PathBuf::from(&module.entry);
+                    let path = directory.as_ref().join(&module.entry);
                     !path.exists()
                 }) {
                     Some(key.clone())

--- a/src/dataflow/lockfile_packages.rs
+++ b/src/dataflow/lockfile_packages.rs
@@ -179,4 +179,8 @@ impl<'a> LockfilePackages<'a> {
             .collect();
         missing_packages
     }
+
+    pub fn extend(&mut self, other_packages: LockfilePackages<'a>) {
+        self.packages.extend(other_packages.packages);
+    }
 }

--- a/src/dataflow/merged_lockfile_packages.rs
+++ b/src/dataflow/merged_lockfile_packages.rs
@@ -64,7 +64,6 @@ impl<'a> MergedLockfilePackages<'a> {
                         commands.insert(name, command);
                     }
                 }
-                PackageKey::LocalPackage { .. } => panic!("Local packages are not supported yet."),
                 PackageKey::GitUrl { .. } => panic!("Git url packages are not supported yet."),
             }
         }

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -122,9 +122,8 @@ pub fn update_with_no_manifest<P: AsRef<Path>>(
         MergedLockfilePackages::merge(added_lockfile_data, retained_lockfile_packages);
 
     let final_package_keys: HashSet<_> = final_lockfile_data.packages.keys().cloned().collect();
-    let is_subset_a = final_package_keys.is_subset(&initial_package_keys);
-    let is_subset_b = initial_package_keys.is_subset(&final_package_keys);
-    let unchanged = is_subset_a && is_subset_b;
+    let unchanged = final_package_keys.is_subset(&initial_package_keys)
+        && initial_package_keys.is_subset(&final_package_keys);
     if !unchanged {
         final_lockfile_data
             .generate_lockfile(&directory)
@@ -151,6 +150,7 @@ pub fn update_with_manifest<P: AsRef<Path>>(
     let lockfile_data =
         LockfilePackages::new_from_result(lockfile_result).map_err(|e| Error::LockfileError(e))?;
 
+    // get the local package modules and commands from the manifest
     let local_package = LocalPackage::new_from_local_package_in_manifest(&manifest);
 
     let changed_manifest_data =
@@ -180,7 +180,6 @@ pub fn update_with_manifest<P: AsRef<Path>>(
     // merge the lockfile data, and generate the new lockfile
     let final_lockfile_data =
         MergedLockfilePackages::merge(manifest_lockfile_data, retained_lockfile_packages);
-
     final_lockfile_data
         .generate_lockfile(&directory)
         .map_err(|e| Error::GenerateLockfileError(e))?;

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -125,16 +125,6 @@ pub fn update_with_no_manifest<P: AsRef<Path>>(
     let is_subset_a = final_package_keys.is_subset(&initial_package_keys);
     let is_subset_b = initial_package_keys.is_subset(&final_package_keys);
     let unchanged = is_subset_a && is_subset_b;
-    println!(
-        "final_package_keys is subset of initial_package_keys: {}",
-        is_subset_a
-    );
-    println!(
-        "initial_package_keys is subset of final_package_keys: {}",
-        is_subset_b
-    );
-    println!("unchanged: {}", unchanged);
-
     if !unchanged {
         final_lockfile_data
             .generate_lockfile(&directory)

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -120,11 +120,8 @@ pub fn update_with_no_manifest<P: AsRef<Path>>(
     // merge the lockfile data, and generate the new lockfile
     let final_lockfile_data =
         MergedLockfilePackages::merge(added_lockfile_data, retained_lockfile_packages);
-
     let final_package_keys: HashSet<_> = final_lockfile_data.packages.keys().cloned().collect();
-    let unchanged = final_package_keys.is_subset(&initial_package_keys)
-        && initial_package_keys.is_subset(&final_package_keys);
-    if !unchanged {
+    if final_package_keys != initial_package_keys {
         final_lockfile_data
             .generate_lockfile(&directory)
             .map_err(|e| Error::GenerateLockfileError(e))?;


### PR DESCRIPTION
This PR adds global install behavior as described in #60. Now, one can run `wapm install` with the `--global/-g` flag. to install modules globally. Installing globally puts a packages into the `WASMER_DIR/globals` directory. 

Running a command will now look in two places. First in the local directory, and then in the global directory. 

For example:
```
> wapm install -g lua
> wapm run lua
```

![global install](https://user-images.githubusercontent.com/1364747/56768450-43e4c480-6763-11e9-81c2-6f6ffcbdbd5f.gif)
