### PR TITLE
uninstall globally or locally with or without manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - List subcommand (`wapm list`) to show packages and commands installed
 - Enforce semantic version numbers on the package and dependencies.
 - Allow ranges of semantic versions when declaring dependencies e.g. `"_/sqlite": "^0.1"`
+- Uninstall a package with `wapm uninstall` and use the `-g` flag for global uninstall.
 ### Changed
 - Refactored process for generating updates to manifest, regenerating the lockfile, and installing packages.
 - Changed OpenSSL to statically link for Linux builds (because version 1.1 is not widely deployed yet)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,5 +27,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed installing packages with http responses that are missing the gzip content encoding header.
 
-[Unreleased]: https://github.com/wasmerio/wapm-cli/compare/0.1.0...HEAD
+[Unreleased]: https://github.com/wasmerio/wapm-cli/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/wasmerio/wapm-cli/releases/tag/v0.1.0

--- a/src/bin/wapm.rs
+++ b/src/bin/wapm.rs
@@ -58,6 +58,10 @@ enum Command {
     #[structopt(name = "list")]
     /// List the currently installed packages and their commands
     List(commands::ListOpt),
+
+    #[structopt(name = "uninstall")]
+    /// Uninstall a package
+    Uninstall(commands::UninstallOpt),
 }
 
 fn main() {
@@ -100,6 +104,7 @@ fn main() {
             );
             Ok(())
         }
+        Command::Uninstall(uninstall_options) => commands::uninstall(uninstall_options),
     };
     if let Err(e) = result {
         eprintln!("Error: {}", e);

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -68,7 +68,7 @@ pub fn install(options: InstallOpt) -> Result<(), failure::Error> {
         (global_flag::LOCAL_INSTALL, package_args::NO_PACKAGES) => {
             // install all packages locally
             let added_packages = vec![];
-            dataflow::update(added_packages, &current_directory)
+            dataflow::update(added_packages, vec![], &current_directory)
                 .map_err(|err| InstallError::FailureInstallingPackages(err))?;
             println!("Packages installed to wapm_packages!");
         }
@@ -122,7 +122,7 @@ pub fn install(options: InstallOpt) -> Result<(), failure::Error> {
                 false => Cow::Borrowed(&current_directory),
             };
 
-            dataflow::update(installed_packages, install_directory)
+            dataflow::update(installed_packages, vec![], install_directory)
                 .map_err(|err| InstallError::CannotRegenLockFile(err))?;
 
             if options.global {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod logout;
 mod publish;
 mod run;
 mod search;
+mod uninstall;
 mod validate;
 mod whoami;
 
@@ -21,5 +22,6 @@ pub use self::logout::logout;
 pub use self::publish::publish;
 pub use self::run::{run, RunOpt};
 pub use self::search::{search, SearchOpt};
+pub use self::uninstall::{uninstall, UninstallOpt};
 pub use self::validate::{validate, ValidateOpt};
 pub use self::whoami::whoami;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -30,7 +30,7 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
     // always update the local lockfile if the manifest has changed
     match is_lockfile_out_of_date(&current_dir) {
         Ok(false) => {}
-        _ => dataflow::update(vec![], &current_dir)
+        _ => dataflow::update(vec![], vec![], &current_dir)
             .map_err(|e| RunError::CannotRegenLockfile(command_name.to_string(), e))?,
     }
 

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,0 +1,22 @@
+use crate::config::Config;
+use crate::dataflow;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct UninstallOpt {
+    pub package: String,
+    /// Uninstall the package(s) globally
+    #[structopt(short = "g", long = "global")]
+    pub global: bool,
+}
+
+pub fn uninstall(options: UninstallOpt) -> Result<(), failure::Error> {
+    let dir = match options.global {
+        true => Config::get_globals_directory()?,
+        false => env::current_dir()?,
+    };
+    let uninstalled_package_names = vec![options.package.as_str()];
+    dataflow::update(vec![], uninstalled_package_names, dir)?;
+    Ok(())
+}

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -18,5 +18,8 @@ pub fn uninstall(options: UninstallOpt) -> Result<(), failure::Error> {
     };
     let uninstalled_package_names = vec![options.package.as_str()];
     dataflow::update(vec![], uninstalled_package_names, dir)?;
+
+    info!("Package \"{}\" is uninstalled.", options.package);
+
     Ok(())
 }

--- a/src/data/manifest.rs
+++ b/src/data/manifest.rs
@@ -85,6 +85,12 @@ impl Manifest {
         dependencies.insert(dependency_name, dependency_version);
     }
 
+    /// remove dependency by package name
+    pub fn remove_dependency(&mut self, dependency_name: String) {
+        let dependencies = self.dependencies.get_or_insert(Default::default());
+        dependencies.remove(&dependency_name);
+    }
+
     pub fn save(&self) -> Result<(), failure::Error> {
         let manifest_string = toml::to_string(self)?;
         let manifest_path = self.base_directory_path.join(MANIFEST_FILE_NAME);

--- a/src/dataflow/lockfile_packages.rs
+++ b/src/dataflow/lockfile_packages.rs
@@ -188,7 +188,7 @@ impl<'a> LockfilePackages<'a> {
         let removed_package_keys = removed_packages
             .packages
             .into_iter()
-            .map(|pkg_name| {
+            .flat_map(|pkg_name| {
                 self.packages
                     .iter()
                     .map(|(package_key, _)| package_key)
@@ -199,7 +199,6 @@ impl<'a> LockfilePackages<'a> {
                     })
                     .collect::<Vec<_>>()
             })
-            .flatten()
             .collect::<Vec<_>>();
 
         for removed_package_key in removed_package_keys {

--- a/src/dataflow/lockfile_packages.rs
+++ b/src/dataflow/lockfile_packages.rs
@@ -3,7 +3,8 @@ use crate::data::lock::lockfile_command::{Error, LockfileCommand};
 use crate::data::lock::lockfile_module::LockfileModule;
 use crate::data::lock::LOCKFILE_NAME;
 use crate::dataflow::installed_packages::InstalledPackages;
-use crate::dataflow::PackageKey;
+use crate::dataflow::removed_packages::RemovedPackages;
+use crate::dataflow::{PackageKey, WapmPackageKey};
 use std::collections::hash_map::HashMap;
 use std::collections::hash_set::HashSet;
 use std::fs;
@@ -181,6 +182,29 @@ impl<'a> LockfilePackages<'a> {
             })
             .collect();
         missing_packages
+    }
+
+    pub fn remove_packages(&mut self, removed_packages: RemovedPackages<'a>) {
+        let removed_package_keys = removed_packages
+            .packages
+            .into_iter()
+            .map(|pkg_name| {
+                self.packages
+                    .iter()
+                    .map(|(package_key, _)| package_key)
+                    .cloned()
+                    .filter(|package_key| match package_key {
+                        PackageKey::WapmPackage(WapmPackageKey { name, .. }) => name == &pkg_name,
+                        _ => false,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+
+        for removed_package_key in removed_package_keys {
+            self.packages.remove(&removed_package_key);
+        }
     }
 
     pub fn extend(&mut self, other_packages: LockfilePackages<'a>) {

--- a/src/dataflow/removed_packages.rs
+++ b/src/dataflow/removed_packages.rs
@@ -1,0 +1,81 @@
+use crate::dataflow::normalize_global_namespace_package_name;
+use std::borrow::Cow;
+use std::collections::hash_set::HashSet;
+
+/// Holds packages that are removed on the cli
+#[derive(Debug, Default)]
+pub struct RemovedPackages<'a> {
+    pub packages: HashSet<Cow<'a, str>>,
+}
+
+impl<'a> RemovedPackages<'a> {
+    pub fn new_from_package_names(removed_packages: Vec<&'a str>) -> Self {
+        let packages = removed_packages
+            .into_iter()
+            .map(|package_name| normalize_global_namespace_package_name(package_name.into()))
+            .collect();
+        Self { packages }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::dataflow::lockfile_packages::{LockfilePackage, LockfilePackages};
+    use crate::dataflow::removed_packages::RemovedPackages;
+    use crate::dataflow::PackageKey;
+    use std::collections::HashMap;
+
+    #[test]
+    fn remove_from_lockfile_packages() {
+        let mut packages = HashMap::default();
+        packages.insert(
+            PackageKey::new_registry_package("_/foo", semver::Version::parse("1.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        packages.insert(
+            PackageKey::new_registry_package("_/bar", semver::Version::parse("2.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        let mut lockfile_packages = LockfilePackages { packages };
+
+        let removed_packages = RemovedPackages::new_from_package_names(vec!["_/foo"]);
+
+        lockfile_packages.remove_packages(removed_packages);
+
+        assert_eq!(1, lockfile_packages.packages.len());
+        lockfile_packages
+            .packages
+            .get(&PackageKey::new_registry_package(
+                "_/bar",
+                semver::Version::parse("2.0.0").unwrap(),
+            ))
+            .unwrap();
+    }
+
+    #[test]
+    fn remove_from_lockfile_packages_using_global_namespace_shorthand() {
+        let mut packages = HashMap::default();
+        packages.insert(
+            PackageKey::new_registry_package("_/foo", semver::Version::parse("1.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        packages.insert(
+            PackageKey::new_registry_package("_/bar", semver::Version::parse("2.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        let mut lockfile_packages = LockfilePackages { packages };
+
+        let removed_packages = RemovedPackages::new_from_package_names(vec!["foo"]);
+
+        lockfile_packages.remove_packages(removed_packages);
+
+        assert_eq!(1, lockfile_packages.packages.len());
+        lockfile_packages
+            .packages
+            .get(&PackageKey::new_registry_package(
+                "_/bar",
+                semver::Version::parse("2.0.0").unwrap(),
+            ))
+            .unwrap();
+    }
+}


### PR DESCRIPTION
This PR addresses the uninstall command suggested in #85. This lets one uninstall packages by package name. This is useful for uninstall packages that are installed globally.  