### PR TITLE
feature - bin scripts

### DIFF
--- a/src/dataflow/bin_script.rs
+++ b/src/dataflow/bin_script.rs
@@ -11,7 +11,7 @@ pub enum Error {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn save_in_script<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
+pub fn save_bin_script<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
     let data = format!("#!/bin/bash\nwapm run {} \"$@\"\n", command_name);
     save(data, directory, command_name)
 }

--- a/src/dataflow/bin_script.rs
+++ b/src/dataflow/bin_script.rs
@@ -1,0 +1,35 @@
+use crate::data::manifest::PACKAGES_DIR_NAME;
+use std::fs;
+use std::path::Path;
+
+const BIN_DIR_NAME: &str = ".bin";
+
+#[derive(Debug, Fail)]
+pub enum Error {
+    #[fail(display = "Could not save script file for command \"{}\". {}", _0, _1)]
+    SaveError(String, failure::Error),
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn save_in_script<P: AsRef<Path>>() -> Result<(), Error> {
+    let data = format!("#!/bin/bash\nwapm run sqlite \"$@\"\n");
+    save(data, directory, command_name)
+}
+
+#[cfg(target_os = "windows")]
+pub fn save_bin_script<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
+    let data = format!("wapm run sqlite %*\n");
+    let file_name = format!("{}.cmd", command_name);
+    save(data, directory, file_name)
+}
+
+fn save<P: AsRef<Path>>(data: String, directory: P, command_name: String) -> Result<(), Error> {
+    let mut dir = directory.as_ref().join(PACKAGES_DIR_NAME);
+    dir.push(BIN_DIR_NAME);
+    if !dir.exists() {
+        fs::create_dir_all(&dir).map_err(|e| Error::SaveError(command_name.clone(), e.into()))?;
+    }
+    let script_path = dir.join(command_name.clone());
+    fs::write(script_path, data).map_err(|e| Error::SaveError(command_name.clone(), e.into()))?;
+    Ok(())
+}

--- a/src/dataflow/bin_script.rs
+++ b/src/dataflow/bin_script.rs
@@ -11,14 +11,14 @@ pub enum Error {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn save_in_script<P: AsRef<Path>>() -> Result<(), Error> {
-    let data = format!("#!/bin/bash\nwapm run sqlite \"$@\"\n");
+pub fn save_in_script<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
+    let data = format!("#!/bin/bash\nwapm run {} \"$@\"\n", command_name);
     save(data, directory, command_name)
 }
 
 #[cfg(target_os = "windows")]
 pub fn save_bin_script<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
-    let data = format!("wapm run sqlite %*\n");
+    let data = format!("wapm run {} %*\n", command_name);
     let file_name = format!("{}.cmd", command_name);
     save(data, directory, file_name)
 }

--- a/src/dataflow/bin_script.rs
+++ b/src/dataflow/bin_script.rs
@@ -4,10 +4,10 @@ use std::path::Path;
 
 const BIN_DIR_NAME: &str = ".bin";
 
-#[derive(Debug, Fail)]
+#[derive(Clone, Debug, Fail)]
 pub enum Error {
     #[fail(display = "Could not save script file for command \"{}\". {}", _0, _1)]
-    SaveError(String, failure::Error),
+    SaveError(String, String),
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -23,13 +23,45 @@ pub fn save_bin_script<P: AsRef<Path>>(directory: P, command_name: String) -> Re
     save(data, directory, file_name)
 }
 
+#[cfg(not(target_os = "windows"))]
+pub fn delete_bin_script<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
+    delete(directory, command_name)
+}
+
+#[cfg(target_os = "windows")]
+pub fn delete_bin_script<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
+    let file_name = format!("{}.cmd", command_name);
+    delete(directory, file_name)
+}
+
+/// save the bin script for a command into the .bin directory
 fn save<P: AsRef<Path>>(data: String, directory: P, command_name: String) -> Result<(), Error> {
     let mut dir = directory.as_ref().join(PACKAGES_DIR_NAME);
     dir.push(BIN_DIR_NAME);
     if !dir.exists() {
-        fs::create_dir_all(&dir).map_err(|e| Error::SaveError(command_name.clone(), e.into()))?;
+        fs::create_dir_all(&dir)
+            .map_err(|e| Error::SaveError(command_name.clone(), e.to_string()))?;
     }
     let script_path = dir.join(command_name.clone());
-    fs::write(script_path, data).map_err(|e| Error::SaveError(command_name.clone(), e.into()))?;
+    fs::write(script_path, data)
+        .map_err(|e| Error::SaveError(command_name.clone(), e.to_string()))?;
     Ok(())
+}
+
+/// delete the bin script for a command - for cleanup during uninstall
+fn delete<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
+    let mut dir = directory.as_ref().join(PACKAGES_DIR_NAME);
+    dir.push(BIN_DIR_NAME);
+    if !dir.exists() {
+        Ok(())
+    } else {
+        let script_path = dir.join(command_name.clone());
+        if script_path.exists() {
+            fs::remove_file(script_path)
+                .map_err(|e| Error::SaveError(command_name.clone(), e.to_string()))?;
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/src/dataflow/merged_lockfile_packages.rs
+++ b/src/dataflow/merged_lockfile_packages.rs
@@ -1,4 +1,5 @@
 use crate::data::lock::lockfile::{CommandMap, Lockfile, ModuleMap};
+use crate::dataflow::bin_script::save_bin_script;
 use crate::dataflow::lockfile_packages::{LockfilePackage, LockfilePackages};
 use crate::dataflow::retained_lockfile_packages::RetainedLockfilePackages;
 use crate::dataflow::{PackageKey, WapmPackageKey};
@@ -61,7 +62,11 @@ impl<'a> MergedLockfilePackages<'a> {
                     }
                     for command in package.commands {
                         let name = command.name.clone();
+                        let script_name = command.name.clone();
                         commands.insert(name, command);
+                        // save the bin script to execute this command from the terminal
+                        save_bin_script(directory, script_name)
+                            .map_err(|e| Error::FailedToSaveLockfile(e.to_string()))?;
                     }
                 }
                 PackageKey::WapmPackageRange(_) => {

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::path::Path;
 
 pub mod added_packages;
+pub mod bin_script;
 pub mod changed_manifest_packages;
 pub mod find_command_result;
 pub mod installed_packages;

--- a/src/dataflow/removed_lockfile_packages.rs
+++ b/src/dataflow/removed_lockfile_packages.rs
@@ -1,0 +1,179 @@
+use crate::dataflow::bin_script::delete_bin_script;
+use crate::dataflow::lockfile_packages::{LockfilePackage, LockfilePackages};
+use crate::dataflow::manifest_packages::ManifestPackages;
+use crate::dataflow::removed_packages::RemovedPackages;
+use crate::dataflow::{bin_script, PackageKey, WapmPackageKey};
+use std::collections::hash_map::HashMap;
+use std::collections::hash_set::HashSet;
+use std::path::Path;
+
+#[derive(Clone, Debug, Fail)]
+pub enum Error {
+    #[fail(display = "Could not cleanup uninstalled command \"{}\". {}", _0, _1)]
+    CommandCleanupError(String, bin_script::Error),
+}
+
+#[derive(Clone, Debug)]
+pub struct RemovedLockfilePackages<'a> {
+    pub packages: HashMap<PackageKey<'a>, LockfilePackage>,
+}
+
+impl<'a> RemovedLockfilePackages<'a> {
+    pub fn from_manifest_and_lockfile(
+        manifest_packages: &'a ManifestPackages<'a>,
+        lockfile_packages: &'a LockfilePackages<'a>,
+    ) -> Self {
+        // collect all removed packages
+        let old_package_keys: HashSet<_> = lockfile_packages.packages.keys().cloned().collect();
+        let packages = old_package_keys
+            .difference(&manifest_packages.packages)
+            .map(|key| {
+                (
+                    key.clone(),
+                    lockfile_packages.packages.get(&key).cloned().unwrap(),
+                )
+            })
+            .collect();
+        Self { packages }
+    }
+
+    pub fn from_removed_packages_and_lockfile(
+        removed_packages: &'a RemovedPackages<'a>,
+        lockfile_packages: &'a LockfilePackages<'a>,
+    ) -> Self {
+        let packages = removed_packages
+            .packages
+            .iter()
+            .cloned()
+            .map(|removed_package_name| {
+                lockfile_packages
+                    .packages
+                    .iter()
+                    .find(|(key, _)| match key {
+                        PackageKey::WapmPackage(WapmPackageKey { name, .. }) => {
+                            name == &removed_package_name
+                        }
+                        _ => unreachable!(
+                            "Lockfile should only contain exact wapm package versions."
+                        ),
+                    })
+                    .map(|(key, data)| (key.clone(), data.clone()))
+                    .unwrap()
+            })
+            .collect();
+        Self { packages }
+    }
+
+    /// This will do the required cleanup of old artifacts like bin scripts and wapm packages
+    pub fn cleanup_old_packages<P: AsRef<Path>>(self, directory: P) -> Result<(), Error> {
+        let directory = directory.as_ref();
+        for (_key, data) in self.packages {
+            for command in data.commands {
+                delete_bin_script(directory, command.name.clone())
+                    .map_err(|e| Error::CommandCleanupError(command.name.clone(), e))?;
+            }
+            // TODO cleanup wapm_packages
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::dataflow::lockfile_packages::{LockfilePackage, LockfilePackages};
+    use crate::dataflow::manifest_packages::ManifestPackages;
+    use crate::dataflow::removed_lockfile_packages::RemovedLockfilePackages;
+    use crate::dataflow::removed_packages::RemovedPackages;
+    use crate::dataflow::PackageKey;
+    use std::collections::hash_set::HashSet;
+    use std::collections::HashMap;
+
+    #[test]
+    fn get_removed_lockfile_packages_from_manifest_and_lockfile() {
+        let mut manifest_packages = ManifestPackages::default();
+        let mut packages = HashSet::default();
+        packages.insert(PackageKey::new_registry_package(
+            "_/foo",
+            semver::Version::parse("1.0.0").unwrap(),
+        ));
+        packages.insert(PackageKey::new_registry_package(
+            "_/bar",
+            semver::Version::parse("2.0.0").unwrap(),
+        ));
+        manifest_packages.packages = packages;
+
+        let mut lockfile_packages = LockfilePackages::default();
+        let mut packages = HashMap::default();
+        packages.insert(
+            PackageKey::new_registry_package("_/foo", semver::Version::parse("1.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        packages.insert(
+            PackageKey::new_registry_package("_/bar", semver::Version::parse("2.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        packages.insert(
+            PackageKey::new_registry_package("_/baz", semver::Version::parse("3.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        lockfile_packages.packages = packages;
+
+        let removed_lockfile_packages = RemovedLockfilePackages::from_manifest_and_lockfile(
+            &manifest_packages,
+            &lockfile_packages,
+        );
+        assert_eq!(1, removed_lockfile_packages.packages.len());
+        removed_lockfile_packages
+            .packages
+            .get(&PackageKey::new_registry_package(
+                "_/baz",
+                semver::Version::parse("3.0.0").unwrap(),
+            ))
+            .unwrap();
+    }
+
+    #[test]
+    fn get_removed_lockfile_packages_from_removed_packages_and_lockfile() {
+        let mut removed_packages = RemovedPackages::default();
+        let mut packages = HashSet::default();
+        packages.insert("_/foo".into());
+        packages.insert("_/bar".into());
+        removed_packages.packages = packages;
+
+        let mut lockfile_packages = LockfilePackages::default();
+        let mut packages = HashMap::default();
+        packages.insert(
+            PackageKey::new_registry_package("_/foo", semver::Version::parse("1.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        packages.insert(
+            PackageKey::new_registry_package("_/bar", semver::Version::parse("2.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        packages.insert(
+            PackageKey::new_registry_package("_/baz", semver::Version::parse("3.0.0").unwrap()),
+            LockfilePackage::default(),
+        );
+        lockfile_packages.packages = packages;
+
+        let removed_lockfile_packages = RemovedLockfilePackages::from_removed_packages_and_lockfile(
+            &removed_packages,
+            &lockfile_packages,
+        );
+        assert_eq!(2, removed_lockfile_packages.packages.len());
+        removed_lockfile_packages
+            .packages
+            .get(&PackageKey::new_registry_package(
+                "_/bar",
+                semver::Version::parse("2.0.0").unwrap(),
+            ))
+            .unwrap();
+        removed_lockfile_packages
+            .packages
+            .get(&PackageKey::new_registry_package(
+                "_/foo",
+                semver::Version::parse("1.0.0").unwrap(),
+            ))
+            .unwrap();
+    }
+}


### PR DESCRIPTION
This PR follows up on #77 global installs feature. This adds another npm-like feature: .bin scripts. This creates a convenient script in the wapm_packages directory. The script gets installed for each command, will be deleted when the command is removed (via `wapm uninstall`)

On windows, a `cmd` script is created. On linux, a `sh` script is created. Right now, they called `wapm run`, but this could change in the future (perhaps call a runtime directly).

Installing `sqlite` with `wapm install sqlite` will create this script:
`pkg/wapm_packages/.bin/sqlite.cmd`

The contents of that file are: `wapm run sqlite %*`
