### PR TITLE
try out windows container builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
           cargo test --verbose -- --test-threads=1
         displayName: 'Test wapm'
   - job: WindowsContainer
+    timeoutInMinutes: 120
     pool:
       vmImage: 'win1803'
     strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,8 @@ resources:
   containers:
     - container: rust133
       image: rust:1.33
+    - container: rust133-windows
+      image: wasmer/windows-rust:latest
 jobs:
   - job: LinuxContainer
     pool:
@@ -21,5 +23,20 @@ jobs:
         displayName: 'Build wapm'
       - script: |
           export PATH=$PATH:$HOME/.cargo/bin
+          cargo test --verbose -- --test-threads=1
+        displayName: 'Test wapm'
+  - job: WindowsContainer
+    pool:
+      vmImage: 'win1803'
+    strategy:
+      matrix:
+        rust133:
+          containerResource: rust133-windows
+    container: $[ variables['containerResource'] ]
+    steps:
+      - script: |
+          cargo build --verbose
+        displayName: 'Build wapm'
+      - script: |
           cargo test --verbose -- --test-threads=1
         displayName: 'Test wapm'


### PR DESCRIPTION
This PR is trying out a windows container for building `wapm-cli` on windows in azure pipelines.

This PR will likely be closed in favor of #92 which does the same, except uses a host VM.

This solution is not ideal for a couple reasons:
- build image is nearly 18 GB
- azure pipelines times-out with the default time of 60 minutes

Although it would be nice to use windows containers, the technology is clearly not a good fit for our CI use-case.

It took 41 minutes to setup the container:
![image](https://user-images.githubusercontent.com/1364747/57025402-e54c9a00-6beb-11e9-895e-93086abf98ef.png)
