### PR TITLE
add bin command

### DIFF
--- a/src/bin/wapm.rs
+++ b/src/bin/wapm.rs
@@ -62,6 +62,10 @@ enum Command {
     #[structopt(name = "uninstall")]
     /// Uninstall a package
     Uninstall(commands::UninstallOpt),
+
+    #[structopt(name = "bin")]
+    /// Get the .bin dir path
+    Bin(commands::BinOpt),
 }
 
 fn main() {
@@ -105,6 +109,7 @@ fn main() {
             Ok(())
         }
         Command::Uninstall(uninstall_options) => commands::uninstall(uninstall_options),
+        Command::Bin(bin_options) => commands::bin(bin_options),
     };
     if let Err(e) = result {
         eprintln!("Error: {}", e);

--- a/src/commands/bin.rs
+++ b/src/commands/bin.rs
@@ -11,12 +11,23 @@ pub struct BinOpt {
     pub global: bool,
 }
 
+#[derive(Clone, Debug, Fail)]
+pub enum BinError {
+    #[fail(display = "The directory does not contain wapm packages.")]
+    NotWapmProjectDir,
+}
+
 pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
     let mut root_dir = match options.global {
         true => Config::get_globals_directory()?,
         false => env::current_dir()?,
     };
     root_dir.push(PACKAGES_DIR_NAME);
+
+    if !root_dir.exists() {
+        return Err(BinError::NotWapmProjectDir.into());
+    }
+
     root_dir.push(BIN_DIR_NAME);
     let bin_dir = root_dir;
     println!("{}", bin_dir.display());

--- a/src/commands/bin.rs
+++ b/src/commands/bin.rs
@@ -13,8 +13,8 @@ pub struct BinOpt {
 
 #[derive(Clone, Debug, Fail)]
 pub enum BinError {
-    #[fail(display = "The directory does not contain wapm packages.")]
-    NotWapmProjectDir,
+    #[fail(display = "The directory \"{}\" does not contain wapm packages.", _0)]
+    NotWapmProjectDir(String),
 }
 
 pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
@@ -25,7 +25,7 @@ pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
     root_dir.push(PACKAGES_DIR_NAME);
 
     if !root_dir.exists() {
-        return Err(BinError::NotWapmProjectDir.into());
+        return Err(BinError::NotWapmProjectDir(root_dir.to_string_lossy().to_string()).into());
     }
 
     root_dir.push(BIN_DIR_NAME);

--- a/src/commands/bin.rs
+++ b/src/commands/bin.rs
@@ -1,0 +1,24 @@
+use crate::config::Config;
+use crate::data::manifest::PACKAGES_DIR_NAME;
+use crate::dataflow::bin_script::BIN_DIR_NAME;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct BinOpt {
+    /// Get the global .bin dir
+    #[structopt(short = "g", long = "global")]
+    pub global: bool,
+}
+
+pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
+    let mut root_dir = match options.global {
+        true => Config::get_globals_directory()?,
+        false => env::current_dir()?,
+    };
+    root_dir.push(PACKAGES_DIR_NAME);
+    root_dir.push(BIN_DIR_NAME);
+    let bin_dir = root_dir;
+    println!("{}", bin_dir.display());
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod bin;
 mod completions;
 mod config;
 mod init;
@@ -12,6 +13,7 @@ mod uninstall;
 mod validate;
 mod whoami;
 
+pub use self::bin::{bin, BinOpt};
 pub use self::completions::CompletionOpt;
 pub use self::config::{config, ConfigOpt};
 pub use self::init::{init, InitOpt};

--- a/src/dataflow/bin_script.rs
+++ b/src/dataflow/bin_script.rs
@@ -2,7 +2,7 @@ use crate::data::manifest::PACKAGES_DIR_NAME;
 use std::fs;
 use std::path::Path;
 
-const BIN_DIR_NAME: &str = ".bin";
+pub const BIN_DIR_NAME: &str = ".bin";
 
 #[derive(Clone, Debug, Fail)]
 pub enum Error {


### PR DESCRIPTION
This PR addresses #88 by adding a new command `wapm bin`.

This command is pretty simple. It prints out the path to the bin scripts directory. Supplying `-g` flag will print the global bin directory path. 