### PR TITLE
add windows build with vm

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ jobs:
           Start-Process -FilePath 'rustup-init.exe' -ArgumentList '-y', '--default-toolchain', 'stable-x86_64-pc-windows-msvc' -Wait
           Remove-Item .\rustup-init.exe
       - script: |
+          set PATH=%PATH%;%USERPROFILE%\.cargo\bin
           cargo -V
           cargo test --verbose -- --test-threads=1
         displayName: 'test wapm'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
           Invoke-WebRequest "https://win.rustup.rs/x86_64" -OutFile rustup-init.exe -UseBasicParsing
           Start-Process -FilePath 'rustup-init.exe' -ArgumentList '-y', '--default-toolchain', 'stable-x86_64-pc-windows-msvc' -Wait
           Remove-Item .\rustup-init.exe
+      - script: |
           cargo -V
           cargo test --verbose -- --test-threads=1
         displayName: 'test wapm'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
           Invoke-WebRequest "https://win.rustup.rs/x86_64" -OutFile rustup-init.exe -UseBasicParsing
           Start-Process -FilePath 'rustup-init.exe' -ArgumentList '-y', '--default-toolchain', 'stable-x86_64-pc-windows-msvc' -Wait
           Remove-Item .\rustup-init.exe
+        displayName: 'install rust'
       - script: |
           set PATH=%PATH%;%USERPROFILE%\.cargo\bin
           cargo -V

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,3 +23,15 @@ jobs:
           export PATH=$PATH:$HOME/.cargo/bin
           cargo test --verbose -- --test-threads=1
         displayName: 'Test wapm'
+  - job: Windows
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+      - powershell: |
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          Invoke-WebRequest "https://win.rustup.rs/x86_64" -OutFile rustup-init.exe -UseBasicParsing
+          Start-Process -FilePath 'rustup-init.exe' -ArgumentList '-y', '--default-toolchain', 'stable-x86_64-pc-windows-msvc' -Wait
+          Remove-Item .\rustup-init.exe
+          cargo -V
+          cargo test --verbose -- --test-threads=1
+        displayName: 'test wapm'


### PR DESCRIPTION
This PR adds a windows build step in azure pipelines. This gives us improved confidence that wapm-cli works cross-platform!

Because the build VM is bundled with the visual studio build tools, we simply install rust and can test `wapm-cli`. The linux container build completes in about the same time.