### PR TITLE
fix panic when uninstalling package that is not installed

### DIFF
--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -5,7 +5,7 @@ use structopt::StructOpt;
 
 #[derive(Clone, Debug, Fail)]
 pub enum Error {
-    #[fail(display = "Packages may be uninstalled with the package name only.")]
+    #[fail(display = "Packages may only be uninstalled by the package name.")]
     NoAtSignAllowed,
 }
 

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -3,6 +3,12 @@ use crate::dataflow;
 use std::env;
 use structopt::StructOpt;
 
+#[derive(Clone, Debug, Fail)]
+pub enum Error {
+    #[fail(display = "Packages may be uninstalled with the package name only.")]
+    NoAtSignAllowed,
+}
+
 #[derive(StructOpt, Debug)]
 pub struct UninstallOpt {
     pub package: String,
@@ -17,6 +23,11 @@ pub fn uninstall(options: UninstallOpt) -> Result<(), failure::Error> {
         false => env::current_dir()?,
     };
     let uninstalled_package_names = vec![options.package.as_str()];
+
+    // do not allow the "@" symbol to prevent mis-use of this command
+    if options.package.contains('@') {
+        return Err(Error::NoAtSignAllowed.into());
+    }
 
     // returned bool indicates if there was any to the lockfile. If this pacakge is uninstalled,
     // there will be a diff created, which causes update to return true. Because no other change

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -36,8 +36,7 @@ pub fn uninstall(options: UninstallOpt) -> Result<(), failure::Error> {
 
     if !result {
         info!("Package \"{}\" is not installed.", options.package);
-    }
-    else {
+    } else {
         info!("Package \"{}\" is uninstalled.", options.package);
     }
 

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -17,9 +17,16 @@ pub fn uninstall(options: UninstallOpt) -> Result<(), failure::Error> {
         false => env::current_dir()?,
     };
     let uninstalled_package_names = vec![options.package.as_str()];
-    dataflow::update(vec![], uninstalled_package_names, dir)?;
 
-    info!("Package \"{}\" is uninstalled.", options.package);
+    // returned bool indicates if there was any change
+    let result = dataflow::update(vec![], uninstalled_package_names, dir)?;
+
+    if !result {
+        info!("Package \"{}\" is not installed.", options.package);
+    }
+    else {
+        info!("Package \"{}\" is uninstalled.", options.package);
+    }
 
     Ok(())
 }

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -18,7 +18,9 @@ pub fn uninstall(options: UninstallOpt) -> Result<(), failure::Error> {
     };
     let uninstalled_package_names = vec![options.package.as_str()];
 
-    // returned bool indicates if there was any change
+    // returned bool indicates if there was any to the lockfile. If this pacakge is uninstalled,
+    // there will be a diff created, which causes update to return true. Because no other change
+    // is made, we can assume any change resulted in successfully uninstalled package.
     let result = dataflow::update(vec![], uninstalled_package_names, dir)?;
 
     if !result {

--- a/src/dataflow/removed_lockfile_packages.rs
+++ b/src/dataflow/removed_lockfile_packages.rs
@@ -45,7 +45,7 @@ impl<'a> RemovedLockfilePackages<'a> {
             .packages
             .iter()
             .cloned()
-            .map(|removed_package_name| {
+            .filter_map(|removed_package_name| {
                 lockfile_packages
                     .packages
                     .iter()
@@ -58,7 +58,6 @@ impl<'a> RemovedLockfilePackages<'a> {
                         ),
                     })
                     .map(|(key, data)| (key.clone(), data.clone()))
-                    .unwrap()
             })
             .collect();
         Self { packages }


### PR DESCRIPTION
This issue fixes an unwrap when uninstalling a package that does not exist. 

It also prints a much better error message when uninstalling a package that is not installed. 

All related to the new uninstall feature for 0.2.0 rel.ease #85 .