### PR TITLE
add explicit logging during reqwests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ prettytable-rs = "0.8.0"
 regex = "1"
 reqwest = {version = "0.9.12", features = ["default-tls-vendored"]}
 semver = "0.9"
-sentry = {version = "0.15", optional = true, features = ["with_panic", "with_backtrace"]}
+sentry = {version = "0.15", optional = true, features = ["with_failure", "with_panic", "with_backtrace"]}
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/bin/wapm.rs
+++ b/src/bin/wapm.rs
@@ -112,7 +112,10 @@ fn main() {
         Command::Bin(bin_options) => commands::bin(bin_options),
     };
     if let Err(e) = result {
-        drop(_guard);
+        #[cfg(feature = "telemetry")]
+        {
+            drop(_guard);
+        };
         eprintln!("Error: {}", e);
         std::process::exit(-1);
     }

--- a/src/bin/wapm.rs
+++ b/src/bin/wapm.rs
@@ -112,6 +112,7 @@ fn main() {
         Command::Bin(bin_options) => commands::bin(bin_options),
     };
     if let Err(e) = result {
+        drop(_guard);
         eprintln!("Error: {}", e);
         std::process::exit(-1);
     }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -107,7 +107,15 @@ pub fn publish() -> Result<(), failure::Error> {
     assert!(archive_path.exists());
     assert!(archive_path.is_file());
     let _response: publish_package_mutation::ResponseData =
-        execute_query_modifier(&q, |f| f.file(archive_name, archive_path).unwrap())?;
+        execute_query_modifier(&q, |f| f.file(archive_name, archive_path).unwrap()).map_err(
+            |e| {
+                #[cfg(feature = "telemetry")]
+                {
+                    sentry::integrations::failure::capture_error(&e);
+                }
+                e
+            },
+        )?;
 
     println!(
         "Successfully published package `{}@{}`",


### PR DESCRIPTION
This PR adds some more explicit logging for sentry logging when making reqwests. The failures are still displayed as normal, except the errors are also published to sentry. This will help us better understand request related failures for users using telemetry. 

fixes #73 