### PR TITLE
do not display error if global .bin directory does not exist

### DIFF
--- a/src/commands/bin.rs
+++ b/src/commands/bin.rs
@@ -15,6 +15,8 @@ pub struct BinOpt {
 pub enum BinError {
     #[fail(display = "The directory \"{}\" does not contain wapm packages.", _0)]
     NotWapmProjectDir(String),
+    #[fail(display = "No global packages installed.")]
+    NoGlobalPackagesInstalled,
 }
 
 pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
@@ -24,6 +26,9 @@ pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
     };
     root_dir.push(PACKAGES_DIR_NAME);
 
+    if !root_dir.exists() && options.global {
+        return Err(BinError::NoGlobalPackagesInstalled.into());
+    }
     if !root_dir.exists() {
         return Err(BinError::NotWapmProjectDir(root_dir.to_string_lossy().to_string()).into());
     }

--- a/src/commands/bin.rs
+++ b/src/commands/bin.rs
@@ -24,6 +24,8 @@ pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
     };
     root_dir.push(PACKAGES_DIR_NAME);
 
+    // for wapm bin -g, display the global path even if it does not exist
+    // otherwise error if the bin directory does not exist in the local directory
     if !root_dir.exists() && !options.global {
         return Err(BinError::NotWapmProjectDir(root_dir.to_string_lossy().to_string()).into());
     }

--- a/src/commands/bin.rs
+++ b/src/commands/bin.rs
@@ -15,8 +15,6 @@ pub struct BinOpt {
 pub enum BinError {
     #[fail(display = "The directory \"{}\" does not contain wapm packages.", _0)]
     NotWapmProjectDir(String),
-    #[fail(display = "No global packages installed.")]
-    NoGlobalPackagesInstalled,
 }
 
 pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
@@ -26,10 +24,7 @@ pub fn bin(options: BinOpt) -> Result<(), failure::Error> {
     };
     root_dir.push(PACKAGES_DIR_NAME);
 
-    if !root_dir.exists() && options.global {
-        return Err(BinError::NoGlobalPackagesInstalled.into());
-    }
-    if !root_dir.exists() {
+    if !root_dir.exists() && !options.global {
         return Err(BinError::NotWapmProjectDir(root_dir.to_string_lossy().to_string()).into());
     }
 


### PR DESCRIPTION
This PR addresses a small issue when using the `wapm bin` command with `-g` flag. The expected behavior is that the global bin directory is always shown even if it does not exist. This PR adds an edge case to only show the error message of missing bin directory if the `-g` flag is absent. 

This issue is covered under #77 issue.