### PR TITLE
validate manifest on publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## **[Unreleased]**
+### Added
+- `--dry-run` flag to `wapm publish` which runs the publish logic without sending anything to the registry
+- validation of the manifest on publish, all commands must reference valid modules
+
+### Changed
+- Lockfile version 3 with package root directory added
 
 ## [0.3.1] - 2019-06-19
 ### Added

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,8 @@ jobs:
           export PATH=$PATH:$HOME/.cargo/bin
           export PATH=$PATH:$HOME/.wasmer/bin
           export WAPM_DISABLE_COLOR=true
+        displayName: 'Pre-regression test set up'
+      - script: |
           rm $WASMER_DIR/wapm.sqlite
           chmod +x end-to-end-tests/install.sh
           echo "RUNNING SCRIPT..."
@@ -51,10 +53,6 @@ jobs:
           exit $OUT
         displayName: 'Regression test: Install, Uninstall, Run, and List'
       - script: |
-          curl https://get.wasmer.io -sSfL | sh
-          export PATH=$PATH:$HOME/.cargo/bin
-          export PATH=$PATH:$HOME/.wasmer/bin
-          export WAPM_DISABLE_COLOR=true
           rm $WASMER_DIR/wapm.sqlite
           chmod +x end-to-end-tests/verification.sh
           echo "RUNNING SCRIPT..."
@@ -72,10 +70,6 @@ jobs:
           exit $OUT
         displayName: 'Regression test: verification and public key management'
       - script: |
-          curl https://get.wasmer.io -sSfL | sh
-          export PATH=$PATH:$HOME/.cargo/bin
-          export PATH=$PATH:$HOME/.wasmer/bin
-          export WAPM_DISABLE_COLOR=true
           rm $HOME/.wasmer/wapm.sqlite
           chmod +x end-to-end-tests/package-fs-mapping.sh
           echo "RUNNING SCRIPT..."
@@ -95,6 +89,24 @@ jobs:
           rm $HOME/.wasmer/wapm.sqlite
           exit $OUT
         displayName: 'Regression test: pkg_fs works globally and when installed locally'
+      - script: |
+          rm $HOME/.wasmer/wapm.sqlite
+          chmod +x end-to-end-tests/manifest-validation.sh
+          echo "RUNNING SCRIPT..."
+          ./end-to-end-tests/manifest-validation.sh &> /tmp/manifest-validation-out.txt
+          echo "GENERATED OUTPUT:"
+          cat /tmp/manifest-validation-out.txt
+          echo "COMPARING..."
+          diff -B end-to-end-tests/manifest-validation.txt /tmp/manifest-validation-out.txt
+          export OUT=$?
+          if ( [ -d globals ] || [ -f wapm.log ] ) then { echo "globals or wapm.log found; these files should not be in the working directory"; exit 1; } else { true; } fi
+          rm wapm.lock
+          rm wapm.toml
+          rm -rf wapm_packages
+          rm /tmp/manifest-validation-out.txt
+          rm $HOME/.wasmer/wapm.sqlite
+          exit $OUT
+        displayName: 'Regression test: manifest validation rejects invalid manifests'
   - job: Windows
     pool:
       vmImage: 'windows-2019'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,11 +31,11 @@ jobs:
         displayName: 'Test wapm'
       - script: |
           curl https://get.wasmer.io -sSfL | sh
+        displayName: 'Pre-regression test set up'
+      - script: |
           export PATH=$PATH:$HOME/.cargo/bin
           export PATH=$PATH:$HOME/.wasmer/bin
           export WAPM_DISABLE_COLOR=true
-        displayName: 'Pre-regression test set up'
-      - script: |
           rm $WASMER_DIR/wapm.sqlite
           chmod +x end-to-end-tests/install.sh
           echo "RUNNING SCRIPT..."
@@ -53,6 +53,9 @@ jobs:
           exit $OUT
         displayName: 'Regression test: Install, Uninstall, Run, and List'
       - script: |
+          export PATH=$PATH:$HOME/.cargo/bin
+          export PATH=$PATH:$HOME/.wasmer/bin
+          export WAPM_DISABLE_COLOR=true
           rm $WASMER_DIR/wapm.sqlite
           chmod +x end-to-end-tests/verification.sh
           echo "RUNNING SCRIPT..."
@@ -70,6 +73,9 @@ jobs:
           exit $OUT
         displayName: 'Regression test: verification and public key management'
       - script: |
+          export PATH=$PATH:$HOME/.cargo/bin
+          export PATH=$PATH:$HOME/.wasmer/bin
+          export WAPM_DISABLE_COLOR=true
           rm $HOME/.wasmer/wapm.sqlite
           chmod +x end-to-end-tests/package-fs-mapping.sh
           echo "RUNNING SCRIPT..."
@@ -90,6 +96,9 @@ jobs:
           exit $OUT
         displayName: 'Regression test: pkg_fs works globally and when installed locally'
       - script: |
+          export PATH=$PATH:$HOME/.cargo/bin
+          export PATH=$PATH:$HOME/.wasmer/bin
+          export WAPM_DISABLE_COLOR=true
           rm $HOME/.wasmer/wapm.sqlite
           chmod +x end-to-end-tests/manifest-validation.sh
           echo "RUNNING SCRIPT..."

--- a/end-to-end-tests/manifest-validation.sh
+++ b/end-to-end-tests/manifest-validation.sh
@@ -7,6 +7,8 @@ wapm publish --dry-run
 # get a wasm module so we forget the abi field
 yes 2> /dev/null | wapm install mark2/dog2@0.0.13
 cp wapm_packages/mark2/dog2@0.0.13/dog.wasm .
-echo '[package]\nname="test"\nversion="0.0.0"\ndescription="this is a test"\n[[module]]\nname="test-module"\nsource="dog.wasm"\n[[command]]\nname="test"\nmodule="test"\n[fs]\n"wapm_file"="src/bin"' > wapm.toml
+echo '[package]\nname="test"\nversion="0.0.0"\ndescription="this is a test"\n[[module]]\nname="test-module"\nsource="dog.wasm"\n[[command]]\nname="test"\nmodule="test-module"\n[fs]\n"wapm_file"="src/bin"' > wapm.toml
+wapm publish --dry-run
+echo '[package]\nname="test"\nversion="0.0.0"\ndescription="this is a test"\n[[module]]\nname="test-module"\nsource="dog.wasm"\nabi="wasi"\n[[command]]\nname="test"\nmodule="test-module"\n[fs]\n"wapm_file"="src/bin"' > wapm.toml
 wapm publish --dry-run
 rm dog.wasm

--- a/end-to-end-tests/manifest-validation.sh
+++ b/end-to-end-tests/manifest-validation.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+alias wapm=target/debug/wapm
+wapm config set registry.url "https://registry.wapm.dev"
+echo '[package]\nname="test"\nversion="0.0.0"\ndescription="this is a test"\n[[command]]\nname="test"\nmodule="test-module"\n[fs]\n"wapm_file"="src/bin"' > wapm.toml
+wapm publish --dry-run
+# get a wasm module so we forget the abi field
+yes 2> /dev/null | wapm install mark2/dog2@0.0.13
+cp wapm_packages/mark2/dog2@0.0.13/dog.wasm .
+echo '[package]\nname="test"\nversion="0.0.0"\ndescription="this is a test"\n[[module]]\nname="test-module"\nsource="dog.wasm"\n[[command]]\nname="test"\nmodule="test"\n[fs]\n"wapm_file"="src/bin"' > wapm.toml
+wapm publish --dry-run
+rm dog.wasm

--- a/end-to-end-tests/manifest-validation.txt
+++ b/end-to-end-tests/manifest-validation.txt
@@ -6,3 +6,5 @@ Would you like to trust this key?
 [INFO] Signature of package dog2@0.0.13 verified!
 Package installed successfully to wapm_packages!
 Error: There was an error validating the manifest: missing ABI field on module test-module used by command test; an ABI of `wasi` or `emscripten` is required
+Successfully published package `test@0.0.0`
+[INFO] Publish succeeded, but package was not published because it was run in dry-run mode

--- a/end-to-end-tests/manifest-validation.txt
+++ b/end-to-end-tests/manifest-validation.txt
@@ -1,0 +1,8 @@
+Error: There was an error validating the manifest: missing module test-module in manifest used by command test
+[INFO] Installing mark2/dog2@0.0.13
+New public key encountered: BB702CB61EC2F2F6 RWT28sIetixwu5p3VkrhG8kyV60RxwQ1ycfHjep8UroIdP8DF4JLmGvt while installing dog2@0.0.13.
+Would you like to trust this key?
+[y/n] [INFO] Importing key "BB702CB61EC2F2F6" for user "mark2"
+[INFO] Signature of package dog2@0.0.13 verified!
+Package installed successfully to wapm_packages!
+Error: There was an error validating the manifest: missing ABI field on module test-module used by command test; an ABI of `wasi` or `emscripten` is required

--- a/src/bin/wapm.rs
+++ b/src/bin/wapm.rs
@@ -25,7 +25,7 @@ enum Command {
 
     #[structopt(name = "publish")]
     /// Publish a package
-    Publish,
+    Publish(commands::PublishOpt),
 
     #[structopt(
         name = "run",
@@ -97,7 +97,7 @@ fn main() {
         Command::Logout => commands::logout(),
         Command::Config(config_options) => commands::config(config_options),
         Command::Install(install_options) => commands::install(install_options),
-        Command::Publish => commands::publish(),
+        Command::Publish(publish_options) => commands::publish(publish_options),
         Command::Run(run_options) => commands::run(run_options),
         Command::Search(search_options) => commands::search(search_options),
         #[cfg(feature = "package")]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,7 +23,7 @@ pub use self::keys::{keys, KeyOpt};
 pub use self::list::{list, ListOpt};
 pub use self::login::login;
 pub use self::logout::logout;
-pub use self::publish::publish;
+pub use self::publish::{publish, PublishOpt};
 pub use self::run::{run, RunOpt};
 pub use self::search::{search, SearchOpt};
 pub use self::uninstall::{uninstall, UninstallOpt};

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -44,11 +44,9 @@ pub fn publish() -> Result<(), failure::Error> {
 
     validate::validate_directory(cwd.clone())?;
 
-    let manifest_path_buf = cwd.join(MANIFEST_FILE_NAME);
-    let contents =
-        fs::read_to_string(&manifest_path_buf).map_err(|_e| PublishError::MissingManifestInCwd)?;
-    let manifest: Manifest = toml::from_str(&contents)?;
+    let manifest = Manifest::find_in_directory(&cwd)?;
 
+    let manifest_path_buf = cwd.join(MANIFEST_FILE_NAME);
     builder.append_path_with_name(&manifest_path_buf, MANIFEST_FILE_NAME)?;
     let package = &manifest.package;
     let modules = manifest.module.as_ref().ok_or(PublishError::NoModule)?;
@@ -176,8 +174,6 @@ enum PublishError {
     NoModule,
     #[fail(display = "Module \"{}\" must have a source that is a file.", _0)]
     SourceMustBeFile(String),
-    #[fail(display = "Missing manifest in current directory.")]
-    MissingManifestInCwd,
     #[fail(display = "Error building package when parsing module \"{}\".", _0)]
     ErrorBuildingPackage(String),
     #[fail(


### PR DESCRIPTION
This will help the data published on wapm be more consistent

examples of some of the new errors:

```
Error: There was an error validating the manifest: missing ABI field on module dog used by command dog; an ABI of `wasi` or `emscripten` is required
Error: There was an error validating the manifest: missing module dog in manifest used by command dog
```