### PR TITLE
automatically suggest a package to install if command not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## **[Unreleased]**
+### Added
+- wapm will now suggest a package to install that contains the desired command if the command is not found
 
 ## [0.3.1] - 2019-06-19
 ### Added

--- a/graphql/queries/get_package_by_command.graphql
+++ b/graphql/queries/get_package_by_command.graphql
@@ -1,0 +1,11 @@
+query GetPackageByCommandQuery ($commandName: String!) {
+  getCommand(name: $commandName) {
+    command
+    packageVersion {
+      version
+      package {
+        displayName
+      }
+    }
+  }
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,5 +1,11 @@
 # source: https://registry.wapm.dev/graphql
-# timestamp: Tue Jun 04 2019 15:18:55 GMT-0700 (Pacific Daylight Time)
+# timestamp: Wed Jun 26 2019 15:36:44 GMT-0700 (Pacific Daylight Time)
+
+type Command {
+  command: String!
+  packageVersion: PackageVersion!
+  module: PackageVersionModule!
+}
 
 type Contract implements Node {
   """The ID of the object."""
@@ -127,8 +133,10 @@ type PackageVersion {
   signature: Signature
   file: String!
   fileSize: Int!
+  commands: [Command]
   distribution: PackageDistribution!
   isLastVersion: Boolean!
+  isSigned: Boolean!
 }
 
 type PackageVersionConnection {
@@ -146,6 +154,13 @@ type PackageVersionEdge {
 
   """A cursor for use in pagination"""
   cursor: String!
+}
+
+type PackageVersionModule {
+  name: String!
+  source: String!
+  abi: String
+  publicUrl: String!
 }
 
 """
@@ -219,9 +234,12 @@ type Query {
   getPackage(name: String!): Package
   getPackages(names: [String!]!): [Package]!
   getPackageVersion(name: String!, version: String): PackageVersion
+  getPackageVersions(names: [String!]!): [PackageVersion]
   getContract(name: String!): Contract
   getContracts(names: [String!]!): [Contract]!
   getContractVersion(name: String!, version: String): ContractVersion
+  getCommand(name: String!): Command
+  getCommands(names: [String!]!): [Command]
   search(query: String!, before: String, after: String, first: Int, last: Int): SearchConnection!
   viewer: User
 }


### PR DESCRIPTION
```
Error: Command python not found, but package python version 0.0.0 has this command. You can install it with `wapm install python@0.0.0`
```
🎉 

Maybe we want to print a message saying we're searching?

Also at some point it might be nice to have config settings for reducing the amount of network traffic or something, if that's a use case that's important to our users