### PR TITLE
Fix bug relating to finding the manifest of globally installed modules

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,6 +181,34 @@ jobs:
         export PATH=$PATH:$HOME/.cargo/bin
         export PATH=$PATH:$HOME/.wasmer/bin
         export WAPM_DISABLE_COLOR=true
+        rm $HOME/.wasmer/wapm.sqlite
+        rm $HOME/.wasmer/globals/wapm.lock
+        rm wapm.lock
+        rm wapm.toml
+        rm -rf wapm_packages
+        chmod +x end-to-end-tests/validate-global.sh
+        echo "RUNNING SCRIPT..."
+        ./end-to-end-tests/validate-global.sh &> /tmp/validate-global-out.txt
+        echo "GENERATED OUTPUT:"
+        cat /tmp/validate-global-out.txt
+        echo "COMPARING..."
+        diff -Bba end-to-end-tests/validate-global.txt /tmp/validate-global-out.txt
+        export OUT=$?
+        if ( [ -d globals ] || [ -f wapm.log ] ) then { echo "globals or wapm.log found; these files should not be in the working directory"; exit 1; } else { true; } fi
+        rm wapm.lock
+        rm wapm.toml
+        rm -rf wapm_packages
+        rm /tmp/validate-global-out.txt
+        rm $HOME/.wasmer/wapm.sqlite
+        if ( [ $OUT -ne 0 ] ) then { cat $HOME/.wasmer/wapm.log; } fi
+        exit $OUT
+      displayName: 'Regression test: package fs and command rename'
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+    - script: |
+        export PATH=$PATH:$HOME/.cargo/bin
+        export PATH=$PATH:$HOME/.wasmer/bin
+        export WAPM_DISABLE_COLOR=true
         rm $WASMER_DIR/wapm.sqlite
         rm $WASMER_DIR/globals/wapm.lock
         rm -rf wapm_packages

--- a/end-to-end-tests/validate-global.sh
+++ b/end-to-end-tests/validate-global.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+alias wapm=target/debug/wapm
+wapm config set registry.url "https://registry.wapm.dev"
+wapm install -g mark2/binary-name-matters -y
+wapm run binary-name-matters
+wapm uninstall -g mark2/binary-name-matters
+wapm install mark2/binary-name-matters -y
+wapm run binary-name-matters
+wapm uninstall mark2/binary-name-matters

--- a/end-to-end-tests/validate-global.txt
+++ b/end-to-end-tests/validate-global.txt
@@ -4,7 +4,7 @@ Success: command name correct
 Success: fs found
 [INFO] Package "mark2/binary-name-matters" is uninstalled.
 [INFO] Installing mark2/binary-name-matters@0.0.0
-Package installed successfully!
+Package installed successfully to wapm_packages!
 Success: command name correct
 ERROR: fs not found
 [INFO] Package "mark2/binary-name-matters" is uninstalled.

--- a/end-to-end-tests/validate-global.txt
+++ b/end-to-end-tests/validate-global.txt
@@ -1,15 +1,10 @@
 [INFO] Installing mark2/binary-name-matters@0.0.0
-[WARN] The server does not have a public key for mark2 for the package binary-name-matters@0.0.0 and the package is not signed but a public key for mark2 is known locally (BB702CB61EC2F2F6).
-This could mean that the wapm registry has been compromised, that the package was created before the publisher started signing their packages, or that the publisher decided not to sign this package.
-Would you like to proceed with an unverified installation?
-[y/n] Global package installed successfully!
+Global package installed successfully!
 Success: command name correct
 Success: fs found
 [INFO] Package "mark2/binary-name-matters" is uninstalled.
 [INFO] Installing mark2/binary-name-matters@0.0.0
-[WARN] The server does not have a public key for mark2 for the package binary-name-matters@0.0.0 and the package is not signed but a public key for mark2 is known locally (BB702CB61EC2F2F6).
-Would you like to proceed with an unverified installation?
-[y/n] Package installed successfully!
+Package installed successfully!
 Success: command name correct
-Success: fs found
+ERROR: fs not found
 [INFO] Package "mark2/binary-name-matters" is uninstalled.

--- a/end-to-end-tests/validate-global.txt
+++ b/end-to-end-tests/validate-global.txt
@@ -1,0 +1,15 @@
+[INFO] Installing mark2/binary-name-matters@0.0.0
+[WARN] The server does not have a public key for mark2 for the package binary-name-matters@0.0.0 and the package is not signed but a public key for mark2 is known locally (BB702CB61EC2F2F6).
+This could mean that the wapm registry has been compromised, that the package was created before the publisher started signing their packages, or that the publisher decided not to sign this package.
+Would you like to proceed with an unverified installation?
+[y/n] Global package installed successfully!
+Success: command name correct
+Success: fs found
+[INFO] Package "mark2/binary-name-matters" is uninstalled.
+[INFO] Installing mark2/binary-name-matters@0.0.0
+[WARN] The server does not have a public key for mark2 for the package binary-name-matters@0.0.0 and the package is not signed but a public key for mark2 is known locally (BB702CB61EC2F2F6).
+Would you like to proceed with an unverified installation?
+[y/n] Package installed successfully!
+Success: command name correct
+Success: fs found
+[INFO] Package "mark2/binary-name-matters" is uninstalled.

--- a/src/data/lock/lockfile_module.rs
+++ b/src/data/lock/lockfile_module.rs
@@ -129,4 +129,18 @@ impl LockfileModule {
 
         lockfile_dir
     }
+
+    /// Returns the Manifest path from the lockfile
+    ///
+    /// This method does extra logic to detect if the lockfile is global and adjusts accordingly
+    pub fn get_canonical_manifest_path_from_lockfile_dir(&self, mut lockfile_dir: PathBuf) -> PathBuf {
+        if crate::config::Config::get_globals_directory().expect("Could not get globals direcotry") == lockfile_dir {
+            lockfile_dir.push(PACKAGES_DIR_NAME);
+            lockfile_dir.push(&self.package_path);
+
+            lockfile_dir
+        } else {
+            lockfile_dir
+        }
+    }
 }

--- a/src/data/lock/lockfile_module.rs
+++ b/src/data/lock/lockfile_module.rs
@@ -133,8 +133,13 @@ impl LockfileModule {
     /// Returns the Manifest path from the lockfile
     ///
     /// This method does extra logic to detect if the lockfile is global and adjusts accordingly
-    pub fn get_canonical_manifest_path_from_lockfile_dir(&self, mut lockfile_dir: PathBuf) -> PathBuf {
-        if crate::config::Config::get_globals_directory().expect("Could not get globals direcotry") == lockfile_dir {
+    pub fn get_canonical_manifest_path_from_lockfile_dir(
+        &self,
+        mut lockfile_dir: PathBuf,
+    ) -> PathBuf {
+        if crate::config::Config::get_globals_directory().expect("Could not get globals direcotry")
+            == lockfile_dir
+        {
             lockfile_dir.push(PACKAGES_DIR_NAME);
             lockfile_dir.push(&self.package_path);
 

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -176,9 +176,11 @@ impl FindCommandResult {
                     Ok(lockfile_module) => {
                         let path = lockfile_module
                             .get_canonical_source_path_from_lockfile_dir(directory.into());
+                        let manifest_dir = lockfile_module
+                            .get_canonical_manifest_path_from_lockfile_dir(directory.into());
                         FindCommandResult::CommandFound {
                             source: path,
-                            manifest_dir: PathBuf::from(directory),
+                            manifest_dir,
                             args: lockfile_command.main_args.clone(),
                             module_name: lockfile_module.name.clone(),
                             prehashed_cache_key: lockfile


### PR DESCRIPTION
I believe, but am not certain, that this was broken with the recent changes to the lockfile