### PR TITLE
Use Boxx version for Wasmer update message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxx"
+version = "0.0.1-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2137,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2554,7 @@ dependencies = [
 name = "wapm-cli"
 version = "0.4.3"
 dependencies = [
+ "boxx 0.0.1-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dialoguer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2766,6 +2787,7 @@ dependencies = [
 "checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+"checksum boxx 0.0.1-alpha (registry+https://github.com/rust-lang/crates.io-index)" = "114de88dc96f4ef76f07376dd671851f466fb4c956b4d1c3cbf889499bb1ba8e"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum bytecount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b92204551573580e078dc80017f36a213eb77a0450e4ddd8cfa0f3f2d1f0178f"
@@ -2987,6 +3009,7 @@ dependencies = [
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+"checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,11 +136,13 @@ dependencies = [
 
 [[package]]
 name = "boxx"
-version = "0.0.1-alpha"
+version = "0.0.2-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strip-ansi-escapes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2033,6 +2035,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "vte 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2178,24 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2451,6 +2479,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,6 +2516,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vte"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "wabt"
@@ -2554,7 +2595,7 @@ dependencies = [
 name = "wapm-cli"
 version = "0.4.3"
 dependencies = [
- "boxx 0.0.1-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "boxx 0.0.2-beta (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dialoguer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2787,7 +2828,7 @@ dependencies = [
 "checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-"checksum boxx 0.0.1-alpha (registry+https://github.com/rust-lang/crates.io-index)" = "114de88dc96f4ef76f07376dd671851f466fb4c956b4d1c3cbf889499bb1ba8e"
+"checksum boxx 0.0.2-beta (registry+https://github.com/rust-lang/crates.io-index)" = "809bc48403e629107c48707b28e9161ce1ea5e391762ec70371a94ebf390a1df"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum bytecount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b92204551573580e078dc80017f36a213eb77a0450e4ddd8cfa0f3f2d1f0178f"
@@ -2998,6 +3039,7 @@ dependencies = [
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
+"checksum strip-ansi-escapes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
@@ -3013,6 +3055,8 @@ dependencies = [
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
+"checksum thiserror-impl 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
@@ -3043,12 +3087,14 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
+"checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum vte 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"
 "checksum wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "74e463a508e390cc7447e70f640fbf44ad52e1bd095314ace1fdf99516d32add"
 "checksum wabt-sys 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a6265b25719e82598d104b3717375e37661d41753e2c84cde3f51050c7ed7e3c"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "WebAssembly Package Manager CLI"
 license = "MIT"
 
 [dependencies]
-boxx = "0.0.1-alpha"
+boxx = { version = "0.0.1-alpha", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 colored = "1.8"
 dirs = "1"
@@ -62,7 +62,7 @@ members = [
 
 [features]
 telemetry = ["sentry"]
-update-notifications= []
+update-notifications= ["boxx"]
 packagesigning = []
 default = ["packagesigning"]
 integration_tests = ["maplit"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "WebAssembly Package Manager CLI"
 license = "MIT"
 
 [dependencies]
+boxx = "0.0.1-alpha"
 chrono = { version = "0.4", features = ["serde"] }
 colored = "1.8"
 dirs = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "WebAssembly Package Manager CLI"
 license = "MIT"
 
 [dependencies]
-boxx = { version = "0.0.1-alpha", optional = true }
+boxx = { version = "0.0.2-beta", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 colored = "1.8"
 dirs = "1"

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -9,7 +9,6 @@ use reqwest::{
     header::{HeaderValue, ACCEPT},
     Client, RedirectPolicy, Response,
 };
-use std::fmt::Write;
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -105,7 +104,7 @@ impl WapmUpdate {
 
                 let release_url = format!("{}{}", GITHUB_RELEASE_URL_BASE, new_version);
                 let message = format_message(&old_version, &new_version, &release_url).unwrap();
-                Boxx::default().display(message);
+                Boxx::builder().border_style(boxx::BorderStyle::Round).build().display(message);
                 self.last_notified = Some(now);
                 self.save()
             }

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -3,16 +3,16 @@
 //! This is turned on in our releases by default but is off when building from source
 
 use crate::{config, proxy, util};
-use boxx::{Boxx, BorderStyle};
+use boxx::{BorderStyle, Boxx};
 use chrono::{DateTime, Utc};
 use colored::*;
 use reqwest::{
     header::{HeaderValue, ACCEPT},
     Client, RedirectPolicy, Response,
 };
+use std::env;
 use std::fs::File;
 use std::path::PathBuf;
-use std::env;
 
 const GITHUB_RELEASE_PAGE: &str = "https://github.com/wasmerio/wasmer/releases/latest";
 const GITHUB_RELEASE_URL_BASE: &str = "https://github.com/wasmerio/wasmer/releases/tag/";
@@ -79,8 +79,10 @@ impl WapmUpdate {
             None => Ok(()),
             Some(last_check) => {
                 let now = Utc::now();
-                let force_update_notification = env::var("WAPM_FORCE_UPDATE_NOTIFICATION").unwrap_or("0".to_string()) != "0".to_string();
-                
+                let force_update_notification = env::var("WAPM_FORCE_UPDATE_NOTIFICATION")
+                    .unwrap_or("0".to_string())
+                    != "0".to_string();
+
                 if !force_update_notification {
                     if let Some(last_notified) = self.last_notified {
                         let time_to_check: time::Duration = time::Duration::from_std(
@@ -114,7 +116,10 @@ impl WapmUpdate {
 
                 let release_url = format!("{}{}", GITHUB_RELEASE_URL_BASE, new_version);
                 let message = format_message(&old_version, &new_version, &release_url).unwrap();
-                Boxx::builder().border_style(BorderStyle::Round).build().display(&message);
+                Boxx::builder()
+                    .border_style(BorderStyle::Round)
+                    .build()
+                    .display(&message);
                 self.last_notified = Some(now);
                 self.save()
             }

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -105,7 +105,7 @@ impl WapmUpdate {
 
                 let release_url = format!("{}{}", GITHUB_RELEASE_URL_BASE, new_version);
                 let message = format_message(&old_version, &new_version, &release_url).unwrap();
-                print!("\n{}", message);
+                Boxx::default().display(message);
                 self.last_notified = Some(now);
                 self.save()
             }
@@ -230,109 +230,17 @@ pub fn try_unlock_background_process() {
     }
 }
 
-const HORIZONTAL_LINE_CHAR: &str = "─";
-const TOP_LEFT_LINE_CHAR: &str = "╭";
-const TOP_RIGHT_LINE_CHAR: &str = "╮";
-const MID_LINE_CHAR: &str = "│";
-const BOT_LEFT_LINE_CHAR: &str = "╰";
-const BOT_RIGHT_LINE_CHAR: &str = "╯";
-const PAD_AMOUNT: usize = 2;
-
-fn prefix_line(out: &mut String) -> Result<(), std::fmt::Error> {
-    for _ in 0..4 {
-        out.write_char(' ')?;
-    }
-    Ok(())
-}
-
-// assumes left, mid, and right are 1 character long
-fn write_solid_line(
-    out: &mut String,
-    max_line_len: usize,
-    left: &str,
-    mid: &str,
-    right: &str,
-) -> Result<(), std::fmt::Error> {
-    prefix_line(out)?;
-    out.write_str(&left.yellow())?;
-    for _ in 0..(max_line_len + PAD_AMOUNT * 2) {
-        out.write_str(&mid.yellow())?;
-    }
-    out.write_str(&right.yellow())?;
-    out.write_char('\n')?;
-    Ok(())
-}
-
-fn write_mid_line(
-    out: &mut String,
-    max_line_len: usize,
-    line_to_write: &str,
-    line_len: usize,
-) -> Result<(), std::fmt::Error> {
-    let size_delta = max_line_len - line_len;
-    let offset_amount = size_delta / 2;
-    prefix_line(out)?;
-    out.write_str(&MID_LINE_CHAR.yellow())?;
-    for _ in 0..offset_amount + PAD_AMOUNT {
-        out.write_char(' ')?;
-    }
-    out.write_str(&line_to_write)?;
-    for _ in 0..(size_delta - offset_amount) + PAD_AMOUNT {
-        out.write_char(' ')?;
-    }
-    out.write_str(&MID_LINE_CHAR.yellow())?;
-    out.write_char('\n')?;
-    Ok(())
-}
-
 fn format_message(
     old_version_str: &str,
     new_version_str: &str,
     changelog_url: &str,
 ) -> Result<String, std::fmt::Error> {
-    let hook_prefix = "There's a new version of wasmer and wapm! ";
-    let hook_prefix_len = hook_prefix.chars().count();
-    let rest_of_hook_len = old_version_str.chars().count() + 3 + new_version_str.chars().count();
-    let hook_len = hook_prefix_len + rest_of_hook_len;
-
-    let changelog_prefix = "Changelog: ";
-    let changelog_prefix_len = changelog_prefix.chars().count();
-    let changelog_len = changelog_prefix_len + changelog_url.chars().count();
-
-    let cta_prefix = "Update with ";
-    let update_command = "wasmer self-update";
-    let cta = format!("{}{}!", cta_prefix, update_command.green().bold());
-    let cta_len = cta_prefix.chars().count() + update_command.chars().count() + 1;
-
-    let max_line_len = std::cmp::max(std::cmp::max(hook_len, changelog_len), cta_len);
-
-    let mut out = String::new();
-
-    write_solid_line(
-        &mut out,
-        max_line_len,
-        TOP_LEFT_LINE_CHAR,
-        HORIZONTAL_LINE_CHAR,
-        TOP_RIGHT_LINE_CHAR,
-    )?;
-    let hook_str = format!(
-        "{}{} → {}",
-        hook_prefix,
+    let out = format!(
+        "There's a new version of wasmer and wapm! {} → {}\nChangelog: {}\nUpdate with {}",
         old_version_str.red(),
-        new_version_str.green()
+        new_version_str.green(),
+        changelog_url,
+        "wasmer self-update".green().bold()
     );
-    write_mid_line(&mut out, max_line_len, &hook_str, hook_len)?;
-    let cl_str = format!("{}{}", changelog_prefix, changelog_url);
-    write_mid_line(&mut out, max_line_len, &cl_str, changelog_len)?;
-    write_mid_line(&mut out, max_line_len, &cta, cta_len)?;
-
-    write_solid_line(
-        &mut out,
-        max_line_len,
-        BOT_LEFT_LINE_CHAR,
-        HORIZONTAL_LINE_CHAR,
-        BOT_RIGHT_LINE_CHAR,
-    )?;
-
     Ok(out)
 }


### PR DESCRIPTION
It seems [Boxx](https://crates.io/crates/boxx) can help us simplify a bit the codebase... so it seems like a great tradeoff!

Great work on the package @EverlastingBugstopper 🎉