### PR TITLE
Allow any WebAssembly runtime in wapm

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::constants::DEFAULT_RUNTIME;
+use crate::util::get_runtime;
 use crate::data::lock::is_lockfile_out_of_date;
 use crate::dataflow;
 use crate::dataflow::find_command_result;
@@ -134,12 +134,13 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
         prehashed_cache_key,
     )?;
     debug!("Running command with args: {:?}", command_vec);
-    let mut child = Command::new(DEFAULT_RUNTIME)
+    let runtime = get_runtime();
+    let mut child = Command::new(&runtime)
         .args(&command_vec)
         .spawn()
         .map_err(|e| -> failure::Error {
             RunError::ProcessFailed {
-                runtime: DEFAULT_RUNTIME.to_string(),
+                runtime: runtime,
                 error: format!("{:?}", e),
             }
             .into()

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,10 +1,10 @@
 use crate::config::Config;
-use crate::util::get_runtime;
 use crate::data::lock::is_lockfile_out_of_date;
 use crate::dataflow;
 use crate::dataflow::find_command_result;
 use crate::dataflow::find_command_result::get_command_from_anywhere;
 use crate::dataflow::manifest_packages::ManifestResult;
+use crate::util::get_runtime;
 use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -135,16 +135,17 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
     )?;
     debug!("Running command with args: {:?}", command_vec);
     let runtime = get_runtime();
-    let mut child = Command::new(&runtime)
-        .args(&command_vec)
-        .spawn()
-        .map_err(|e| -> failure::Error {
-            RunError::ProcessFailed {
-                runtime: runtime,
-                error: format!("{:?}", e),
-            }
-            .into()
-        })?;
+    let mut child =
+        Command::new(&runtime)
+            .args(&command_vec)
+            .spawn()
+            .map_err(|e| -> failure::Error {
+                RunError::ProcessFailed {
+                    runtime: runtime,
+                    error: format!("{:?}", e),
+                }
+                .into()
+            })?;
 
     child.wait()?;
     Ok(())

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,5 @@
 pub const DEFAULT_RUNTIME: &str = "wasmer";
+pub const WAPM_RUNTIME_ENV_KEY: &str = "WAPM_RUNTIME";
 
 pub const RFC3339_FORMAT_STRING: &'static str = "%Y-%m-%dT%H:%M:%S-%f";
 pub const RFC3339_FORMAT_STRING_WITH_TIMEZONE: &'static str = "%Y-%m-%dT%H:%M:%S.%f+%Z";

--- a/src/update_notifier.rs
+++ b/src/update_notifier.rs
@@ -89,7 +89,9 @@ impl WapmUpdate {
                 }
 
                 let new_version = last_check.version.to_owned();
-                let old_version = util::get_latest_runtime_version()?;
+                // We use wasmer and not constants::DEFAULT_RUNTIME because the
+                // update logic is very tied to wasmer itself.
+                let old_version = util::get_latest_runtime_version("wasmer")?;
 
                 if let Some(b) = util::compare_versions(&old_version, &new_version) {
                     if b {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,11 @@
-#[cfg(feature = "update-notifications")]
-use crate::constants;
+use crate::constants::{DEFAULT_RUNTIME, WAPM_RUNTIME_ENV_KEY};
 use crate::data::manifest::PACKAGES_DIR_NAME;
 use crate::graphql::execute_query;
 use graphql_client::*;
 use license_exprs;
 use semver::Version;
 use std::path::{Path, PathBuf};
-use std::{fs, io};
+use std::{env, fs, io};
 
 pub static MAX_NAME_LENGTH: usize = 50;
 
@@ -219,17 +218,17 @@ pub fn get_hashed_module_key(path: &Path) -> Option<String> {
 }
 
 #[cfg(feature = "update-notifications")]
-pub fn get_latest_runtime_version() -> Result<String, String> {
+pub fn get_latest_runtime_version(runtime: &str) -> Result<String, String> {
     use std::process::Command;
 
-    let output = Command::new(constants::DEFAULT_RUNTIME)
+    let output = Command::new(runtime)
         .arg("-V")
         .output()
         .map_err(|err| err.to_string())?;
     let stdout_str = std::str::from_utf8(&output.stdout).map_err(|err| err.to_string())?;
     let mut whitespace_iter = stdout_str.split_whitespace();
     let _first = whitespace_iter.next();
-    debug_assert_eq!(_first, Some(constants::DEFAULT_RUNTIME));
+    debug_assert_eq!(_first, Some(runtime));
 
     match whitespace_iter.next() {
         Some(v) => Ok(v.to_string()),
@@ -280,4 +279,8 @@ mod test {
         assert_eq!(compare_versions("0.1.1", "0.1.0"), Some(true));
         assert_eq!(compare_versions("0.1.1", "0.2.0"), Some(false));
     }
+}
+
+pub fn get_runtime() -> String {
+    env::var(WAPM_RUNTIME_ENV_KEY).unwrap_or(DEFAULT_RUNTIME.to_owned())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -281,6 +281,8 @@ mod test {
     }
 }
 
+/// Returns the value of the WAPM_RUNTIME env var if it exists.
+/// Otherwise returns wasmer
 pub fn get_runtime() -> String {
     env::var(WAPM_RUNTIME_ENV_KEY).unwrap_or(DEFAULT_RUNTIME.to_owned())
 }


### PR DESCRIPTION
With the proliferation of server-side WebAssembly runtimes, it's becoming more useful to being able to use other runtimes for multiple proposes (debugging, speed comparison, ...).

This PR enables to use any WebAssembly runtime in wapm via the `WAPM_RUNTIME` environment var.

So you can do things like:

```bash
wapm install python
WAPM_RUNTIME=wasmer-js wapm run python  # or wasm3, ...
```
