### PR TITLE
Fixed link for WAPM documentation and a few nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ The WebAssembly Package Manager CLI. This tool enables installing, managing, and
 
 ## Get Started
 
-Read the [`wapm-cli` user guide on `wapm.io`][guide] to get started using the tool and use the [`wapm-cli` reference][reference]
-for information about the cli commands.
+Read the [`wapm-cli` user guide on `wapm.io`][guide] to get started using the tool and use the [`wapm-cli` reference][reference] for information about the CLI commands.
 
 ## Get Help
 
-Feel free to take a look at the [Wapm Documentation](https://docs.wasmer.io/wapm/wapm). You can also join the discussion on [spectrum chat][spectrum] in the `wapm-cli` channel, or create a GitHub issue. We love to help!
+Feel free to take a look at the [WAPM documentation](https://docs.wasmer.io/ecosystem/wapm). You can also join the discussion on [spectrum chat][spectrum] in the `wapm-cli` channel, or create a GitHub issue. We love to help!
 
 ## Contributing
 
@@ -43,7 +42,7 @@ If the WAPM GraphQL server has been updated, update the GraphQL schema with:
 graphql get-schema -e prod
 ```
 
-_Note: You will need graphql-cli installed for it `npm install -g graphql-cli`._
+_Note: You will need `graphql-cli` installed for this: `npm install -g graphql-cli`._
 
 [contributing]: CONTRIBUTING.md
 [guide]: https://wapm.io/help/guide


### PR DESCRIPTION
* The "WAPM documentation" link now points correctly to https://docs.wasmer.io/ecosystem/wapm (was previously a dead link).
* Changed casing for a few words to be more correct or consistent.

One issue: the [wapm.io guide page](https://wapm.io/help/guide) seems to differ from the [WAPM page on the wasmer.io documentation website](https://docs.wasmer.io/ecosystem/wapm): the formers uses "wasm", the latter "WASM". For example, the "What is wapm?" section header should probably read "What is WAPM?" to make it more consistent with the other page. (That, or the reverse can be done, I suppose.) Likewise with the other instances of "wasm" on that page. Of course, if the command-line program name is being referred to, then it should probably be formatted as `wasm`. I'd be happy to submit a PR for the wapm.io guide, but I'm not sure that has a repo anywhere...