### PR TITLE
Add offline mode to wax

### DIFF
--- a/end-to-end-tests/direct_execute.sh
+++ b/end-to-end-tests/direct_execute.sh
@@ -16,3 +16,4 @@ wapm uninstall lolcat
 wapm list -a
 rm -rf $(./wax --which lolcat)/wapm_packages/_/lolcat@0.1.1/*
 ./wax lolcat -V
+./wax --offline lolcat -V

--- a/end-to-end-tests/direct_execute.txt
+++ b/end-to-end-tests/direct_execute.txt
@@ -20,3 +20,4 @@ Package installed successfully to wapm_packages!
 No packages found
 [INFO] Installing _/lolcat@0.1.1
 "wapm-run-lolcat" 1.0.1
+"wapm-run-lolcat" 1.0.1


### PR DESCRIPTION
Adds an opt-in offline mode `--offline` and an auto-detected offline mode.  Error messages adapt to the flow the user is in