### PR TITLE
Use the raw command name by default

### DIFF
--- a/end-to-end-tests/direct_execute.txt
+++ b/end-to-end-tests/direct_execute.txt
@@ -13,14 +13,14 @@ hello
                 ||     ||
 [INFO] Installing _/lolcat@0.1.1
 Package installed successfully to wapm_packages!
-wapm-run-lolcat 1.0.1
-wax-lolcat 1.0.1
+lolcat 1.0.1
+lolcat 1.0.1
 [INFO] Package "lolcat" is uninstalled.
 [INFO] Installing _/lolcat@0.1.1
-wax-lolcat 1.0.1
+lolcat 1.0.1
 No packages found
 [INFO] Installing _/lolcat@0.1.1
-wax-lolcat 1.0.1
-wax-lolcat 1.0.1
+lolcat 1.0.1
+lolcat 1.0.1
 Success: command-name not found
 

--- a/end-to-end-tests/validate-global.sh
+++ b/end-to-end-tests/validate-global.sh
@@ -4,10 +4,10 @@ alias wapm=target/debug/wapm
 wapm config set registry.url "https://registry.wapm.dev"
 
 # test that the command name is overriden by default
-wapm install -g mark2/binary-name-matters -y
+wapm install -g mark2/binary-name-matters@0.0.3 -y
 wapm run binary-name-matters
 wapm uninstall -g mark2/binary-name-matters
-wapm install mark2/binary-name-matters -y
+wapm install mark2/binary-name-matters@0.0.3 -y
 wapm run binary-name-matters
 wapm uninstall mark2/binary-name-matters
 

--- a/end-to-end-tests/validate-global.txt
+++ b/end-to-end-tests/validate-global.txt
@@ -1,9 +1,9 @@
-[INFO] Installing mark2/binary-name-matters@0.0.2
+[INFO] Installing mark2/binary-name-matters@0.0.3
 Global package installed successfully!
 Success: command name correct
 Success: fs found
 [INFO] Package "mark2/binary-name-matters" is uninstalled.
-[INFO] Installing mark2/binary-name-matters@0.0.2
+[INFO] Installing mark2/binary-name-matters@0.0.3
 Package installed successfully to wapm_packages!
 Success: command name correct
 Success: fs found

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -300,7 +300,6 @@ pub fn execute(opt: ExecuteOpt) -> Result<(), failure::Error> {
                 &opt.pre_opened_directories,
                 &opt.args,
                 prehashed_cache_key,
-                &default_wax_command_name_formatter,
             )?;
             return Ok(());
         }
@@ -553,7 +552,6 @@ fn run(
                 pre_opened_directories,
                 args,
                 prehashed_cache_key,
-                &default_wax_command_name_formatter,
             );
         }
         FindCommandResult::Error(e) => return Err(e),
@@ -598,8 +596,4 @@ fn get_wax_cooldown() -> i32 {
         .ok()
         .map(|c| c.wax_cooldown)
         .unwrap_or(config::wax_default_cooldown())
-}
-
-fn default_wax_command_name_formatter(command_name: &str) -> String {
-    format!("wax {}", command_name)
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -75,12 +75,7 @@ pub fn run(run_options: RunOpt) -> Result<(), failure::Error> {
         &run_options.pre_opened_directories,
         &args,
         prehashed_cache_key,
-        &default_wapm_command_name_formatter,
     )
-}
-
-fn default_wapm_command_name_formatter(command_name: &str) -> String {
-    format!("wapm run {}", command_name)
 }
 
 pub(crate) fn do_run(
@@ -92,7 +87,6 @@ pub(crate) fn do_run(
     pre_opened_directories: &[String],
     args: &[OsString],
     prehashed_cache_key: Option<String>,
-    command_name_formatter: &dyn Fn(&str) -> String,
 ) -> Result<(), failure::Error> {
     debug!(
         "Running module located at {:?}",
@@ -130,13 +124,10 @@ pub(crate) fn do_run(
         .collect();
 
     let mut disable_command_rename = false;
-    let mut rename_commands_to_raw_command_name = false;
 
     match ManifestResult::find_in_directory(&manifest_dir) {
         ManifestResult::Manifest(manifest) => {
             disable_command_rename = manifest.package.disable_command_rename;
-            rename_commands_to_raw_command_name =
-                manifest.package.rename_commands_to_raw_command_name;
             if let Some(ref fs) = manifest.fs {
                 // todo: normalize (rm `:` and newline, etc) these paths if we haven't yet
                 for (guest_path, host_path) in fs.iter() {
@@ -160,11 +151,7 @@ pub(crate) fn do_run(
     let command_override_name = if !using_default_runtime || disable_command_rename {
         None
     } else {
-        if rename_commands_to_raw_command_name {
-            Some(command_name.to_string())
-        } else {
-            Some(command_name_formatter(command_name))
-        }
+        Some(command_name.to_string())
     };
     let command_vec = create_run_command(
         args,

--- a/src/data/manifest.rs
+++ b/src/data/manifest.rs
@@ -30,16 +30,6 @@ pub struct Package {
         skip_serializing_if = "std::ops::Not::not"
     )]
     pub disable_command_rename: bool,
-    /// Unlike, `disable-command-rename` which prevents `wapm run <Module name>`,
-    /// this flag enables the command rename of `wapm run <COMMAND_NAME>` into
-    /// just `<COMMAND_NAME>. This is useful for programs that need to inspect
-    /// their argv[0] names and when the command name matches their executable name.
-    #[serde(
-        rename = "rename-commands-to-raw-command-name",
-        default,
-        skip_serializing_if = "std::ops::Not::not"
-    )]
-    pub rename_commands_to_raw_command_name: bool,
 }
 
 /// Describes a command for a wapm module

--- a/src/init.rs
+++ b/src/init.rs
@@ -97,7 +97,6 @@ pub fn init(dir: PathBuf, force_yes: bool) -> Result<(), failure::Error> {
                 wasmer_extra_flags: None,
                 readme: None,
                 disable_command_rename: false,
-                rename_commands_to_raw_command_name: false,
             },
             dependencies: None,
             module: Some(vec![Module {


### PR DESCRIPTION
rather than adding a flag in #182, we just make it the default.  This PR will break tests...

We used to update `argv[0]` to be `wapm run command-name`, now it will just be `command-name`.  This differs from the default of what Wasm runtimes will typically do; Wasmer uses the Wasm file's name as argv[0] (at least in WASI).