### PR TITLE
Allow having runtime with args in WAPM_RUNTIME

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -5,7 +5,7 @@ use crate::dataflow;
 use crate::dataflow::find_command_result;
 use crate::dataflow::find_command_result::get_command_from_anywhere;
 use crate::dataflow::manifest_packages::ManifestResult;
-use crate::util::{get_runtime, split_runtime_and_args};
+use crate::util::get_runtime_with_args;
 use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -143,7 +143,7 @@ pub(crate) fn do_run(
         _ => (),
     }
 
-    let (runtime, runtime_args) = split_runtime_and_args(get_runtime());
+    let (runtime, runtime_args) = get_runtime_with_args();
 
     // avoid `wasmer-js`, allow other wasmers
     let using_default_runtime = Path::new(&runtime)

--- a/src/util.rs
+++ b/src/util.rs
@@ -329,5 +329,19 @@ mod test {
             split_runtime_and_args("wasmer run".to_owned()),
             ("wasmer".to_owned(), vec!["run".to_owned()])
         );
+
+        // Weird spacing
+        assert_eq!(
+            split_runtime_and_args("  wasmer   ".to_owned()),
+            ("wasmer".to_owned(), vec![])
+        );
+        assert_eq!(
+            split_runtime_and_args("wasmer  run  ".to_owned()),
+            ("wasmer".to_owned(), vec!["run".to_owned()])
+        );
+        assert_eq!(
+            split_runtime_and_args("  wasmer  run  ".to_owned()),
+            ("wasmer".to_owned(), vec!["run".to_owned()])
+        );
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -273,12 +273,12 @@ pub fn compare_versions(old: &str, new: &str) -> Option<bool> {
 
 /// Returns the value of the WAPM_RUNTIME env var if it exists.
 /// Otherwise returns wasmer
-pub fn get_runtime() -> String {
+fn get_runtime() -> String {
     env::var(WAPM_RUNTIME_ENV_KEY).unwrap_or(DEFAULT_RUNTIME.to_owned())
 }
 
 /// Splits the runtime from the rest of arguments
-pub fn split_runtime_and_args(runtime: String) -> (String, Vec<String>) {
+fn split_runtime_and_args(runtime: String) -> (String, Vec<String>) {
     let runtime_split = runtime.split_whitespace();
     if let Some((split_runtime, split_runtime_args)) = runtime_split
         .map(|s| s.to_string())
@@ -288,6 +288,13 @@ pub fn split_runtime_and_args(runtime: String) -> (String, Vec<String>) {
         return (split_runtime.to_string(), split_runtime_args.to_vec());
     }
     (runtime, vec![])
+}
+
+/// We put this in a new function, to be clear that runtime can be both
+/// 1. A string with the runtime value (eg. "wasmer")
+/// 2. A string with the runtime value and the args (eg. "wasmer --backend=singlepass")
+pub fn get_runtime_with_args() -> (String, Vec<String>) {
+    split_runtime_and_args(get_runtime())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR allows for having arguments specified on the `WAPM_RUNTIME`.

This allows for nice usage like:

```shell
WAPM_RUNTIME="wax wasm3" wax quickjs # Executes things with the wasm3 interpreter compiled to wasm
WAPM_RUNTIME="wasmer --backend=singlepass" wax quickjs
WAPM_RUNTIME="wavm run" wax quickjs # Run it with wavm
```

Note: I tested all those (except the first one, that requires wasm3 to accept a `--dir` argument: https://github.com/wasm3/wasm3/issues/119 )