### PR TITLE
update blake3 to version 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2523,7 +2523,7 @@ version = "0.5.0"
 dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "billboard 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake3 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake3 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dialoguer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2747,7 +2747,7 @@ dependencies = [
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-"checksum blake3 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c58fbca3e5be3b7a3c24a5ec6976a6a464490528e8fee92896fe4ee2a40b10fb"
+"checksum blake3 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7bd3c29b0e8eedf3a4424b8b2ee09518fc9e95b7efe257000c356827e6353584"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ wasmparser = "0.51.4"
 whoami = "0.5"
 dialoguer = "0.4.0"
 hex = { version = "0.4", optional = true }
-blake3 = { version = "0.2.0", optional = true }
+blake3 = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Version 0.3 switched to using assembly implementations by default, which
both perform better and build more quickly. This invokes the C compiler
from build.rs. If Wasmer would prefer to avoid that build dependency, we
could enable the new `pure` feature.