### PR TITLE
chore: turn off echoing of windows bin script

### DIFF
--- a/src/dataflow/bin_script.rs
+++ b/src/dataflow/bin_script.rs
@@ -22,7 +22,7 @@ pub fn save_bin_script<P: AsRef<Path>>(directory: P, command_name: String) -> Re
 
 #[cfg(target_os = "windows")]
 pub fn save_bin_script<P: AsRef<Path>>(directory: P, command_name: String) -> Result<(), Error> {
-    let data = format!("wapm run {} %*\n", command_name);
+    let data = format!("@\"wapm\" run {} %*\n", command_name);
     let file_name = format!("{}.cmd", command_name);
     save(data, directory, file_name)
 }


### PR DESCRIPTION
This PR turns Windows bin scripts command-echoing off.

**Before**
```
$ cowsay.cmd Hello WASM

C:\[omitted]>wapm run cowsay Hello WASM
 ____________
< Hello WASM >
 ------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
               ||----w |
                ||     ||
```

**After**
```
$ cowsay.cmd Hello WASM
 ____________
< Hello WASM >
 ------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
               ||----w |
                ||     ||
```
