### PR TITLE
Fix an error opening logging file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -122,7 +122,10 @@ impl Config {
                 .ok()
                 .filter(|s| !s.is_empty())
             {
-                PathBuf::from(folder_str)
+                let folder = PathBuf::from(folder_str);
+                std::fs::create_dir_all(folder.clone())
+                    .map_err(|e| GlobalConfigError::CannotCreateConfigDirectory(e))?;
+                folder
             } else {
                 #[allow(unused_variables)]
                 let default_dir = Self::get_current_dir()


### PR DESCRIPTION
This PR might resolve: https://github.com/wasmerio/wapm-cli/issues/170

When the `$HOME/.wasmer` directory exported as an env variable as `WASMER_DIR` does not exist, any `wapm` command reports the following error.

```bash
$ wapm                          
Error: Failed to open logging file in WASMER_DIR: log_out: "/Users/user/.wasmer/wapm.log", error type: NotFound
```

If my understanding is correct, this problem can be reproduced when the two conditions that the env variable is exported and that the `$HOME/.wasmer` does not exist are met. Accordingly, I think the problem is that the current code assumes that if the env variable is exported, then the directory exists. So I resolved this problem by enforcing creating the directory even if the env variable is found.