### PR TITLE
Locate license file on publish if missing from manifest

### DIFF
--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -77,13 +77,7 @@ pub fn publish(publish_opts: PublishOpt) -> anyhow::Result<()> {
         }
         fs::read_to_string(normalized_path).ok()
     });
-    // include a LICENSE file if it exists and an explicit license_file was not given
-    if package.license_file.is_none() {
-        let license_path = PathBuf::from("LICENSE");
-        if license_path.exists() {
-            builder.append_path(license_path).ok();
-        }
-    }
+
     for module in modules {
         let normalized_path = normalize_path(&manifest.base_directory_path, &module.source);
         normalized_path

--- a/src/data/manifest.rs
+++ b/src/data/manifest.rs
@@ -88,16 +88,10 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    fn locate_readme(path: &Path) -> Option<PathBuf> {
-        for filename in [
-            "README",
-            "README.md",
-            "README.markdown",
-            "README.mdown",
-            "README.mkdn",
-        ] {
-            let readme_path_buf = path.join(filename);
-            if readme_path_buf.exists() {
+    fn locate_file(path: &Path, candidates: &[&str]) -> Option<PathBuf> {
+        for filename in candidates {
+            let path_buf = path.join(filename);
+            if path_buf.exists() {
                 return Some(filename.into());
             }
         }
@@ -119,7 +113,20 @@ impl Manifest {
         let mut manifest: Self = toml::from_str(contents.as_str())
             .map_err(|e| ManifestError::TomlParseError(e.to_string()))?;
         if manifest.package.readme.is_none() {
-            manifest.package.readme = Self::locate_readme(path.as_ref());
+            manifest.package.readme = Self::locate_file(
+                path.as_ref(),
+                &[
+                    "README",
+                    "README.md",
+                    "README.markdown",
+                    "README.mdown",
+                    "README.mkdn",
+                ],
+            );
+        }
+        if manifest.package.license_file.is_none() {
+            manifest.package.license_file =
+                Self::locate_file(path.as_ref(), &["LICENSE", "LICENSE.md", "COPYING"]);
         }
         manifest.validate()?;
         Ok(manifest)


### PR DESCRIPTION
Depends on PR #228 

This patch adds autodiscovery of the license file of a package if it's missing from the package manifest by checking for the existence of common license filenames.