### PR TITLE
Let modules tell wapm.toml which interfaces they export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -1953,6 +1953,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+dependencies = [
  "serde",
 ]
 
@@ -2709,7 +2717,7 @@ dependencies = [
  "reqwest",
  "rpassword-wasi",
  "rusqlite",
- "semver",
+ "semver 1.0.13",
  "sentry",
  "serde",
  "serde_derive",
@@ -2737,7 +2745,7 @@ name = "wapm-toml"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "semver",
+ "semver 1.0.13",
  "serde",
  "serde_cbor",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,6 +2743,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ prettytable-rs = { version = "0.8.0", optional = true }
 regex = "1"
 rpassword-wasi = "5"
 rusqlite = { version = "0.24", optional = true }
-semver = { version = "0.11", features = ["serde"] }
+semver = { version = "1.0", features = ["serde"] }
 sentry = { version = "0.22.0", optional = true, features = ["anyhow", "panic", "backtrace"] }
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -87,9 +87,9 @@ pub fn publish(publish_opts: PublishOpt) -> anyhow::Result<()> {
             .append_path(normalized_path)
             .map_err(|_| PublishError::ErrorBuildingPackage(module.name.clone()))?;
 
-        if let Some(exports) = module.exports {
-            for path in exports.referenced_files(&manifest.base_directory_path) {
-                let normalized_path = normalize_path(&manifest.base_directory_path, &module.source);
+        if let Some(bindings) = &module.bindings {
+            for path in bindings.referenced_files(&manifest.base_directory_path) {
+                let normalized_path = normalize_path(&manifest.base_directory_path, &path);
                 normalized_path
                     .metadata()
                     .map_err(|_| PublishError::SourceMustBeFile(module.name.clone()))?;

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -86,6 +86,18 @@ pub fn publish(publish_opts: PublishOpt) -> anyhow::Result<()> {
         builder
             .append_path(normalized_path)
             .map_err(|_| PublishError::ErrorBuildingPackage(module.name.clone()))?;
+
+        if let Some(exports) = module.exports {
+            for path in exports.referenced_files(&manifest.base_directory_path) {
+                let normalized_path = normalize_path(&manifest.base_directory_path, &module.source);
+                normalized_path
+                    .metadata()
+                    .map_err(|_| PublishError::SourceMustBeFile(module.name.clone()))?;
+                builder
+                    .append_path(normalized_path)
+                    .map_err(|_| PublishError::ErrorBuildingPackage(module.name.clone()))?;
+            }
+        }
     }
 
     // bundle the package filesystem

--- a/src/data/lock/lockfile_command.rs
+++ b/src/data/lock/lockfile_command.rs
@@ -60,6 +60,6 @@ impl<'a> LockfileCommand {
 pub enum Error {
     #[error("The module for this command does not exist. Did you modify the wapm.lock?")]
     ModuleForCommandDoesNotExist,
-    #[error("Could not parse the package name and version \"{0}\" for the command \"{}\".")]
+    #[error("Could not parse the package name and version \"{0}\" for the command \"{1}\".")]
     CouldNotParsePackageVersionForCommand(String, String),
 }

--- a/src/dataflow/find_command_result.rs
+++ b/src/dataflow/find_command_result.rs
@@ -62,11 +62,11 @@ pub enum Error {
     )]
     ErrorReadingLocalDirectory(String, String),
     #[error(
-        "Command \"{0}\" exists in lockfile, but corresponding module \"{}\" not found in lockfile.",
+        "Command \"{0}\" exists in lockfile, but corresponding module \"{1}\" not found in lockfile.",
     )]
     CommandFoundButCorrespondingModuleIsMissing(String, String),
     #[error(
-        "Failed to get command \"{0}\" because there was an error opening the global installation directory. {}",
+        "Failed to get command \"{0}\" because there was an error opening the global installation directory. {1}",
     )]
     CouldNotOpenGlobalsDirectory(String, String),
 }

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -65,7 +65,7 @@ pub struct WapmPackageKey<'a> {
 }
 
 /// A range of versions for a package in the wapm.io registry.
-#[derive(Clone, Debug, Eq, Hash, PartialOrd, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct WapmPackageRange<'a> {
     pub name: Cow<'a, str>,
     pub version_req: VersionReq,
@@ -105,7 +105,7 @@ pub fn detect_duplicate_packages(packages: &HashSet<PackageKey>) -> Result<(), E
 /// A package key can be anything reference to a package, be it a wapm.io registry, a local directory.
 /// Currently, only wapm.io keys are supported.
 #[allow(dead_code)]
-#[derive(Clone, Debug, Eq, Hash, PartialOrd, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PackageKey<'a> {
     WapmPackage(WapmPackageKey<'a>),
     WapmPackageRange(WapmPackageRange<'a>),

--- a/src/init.rs
+++ b/src/init.rs
@@ -107,6 +107,7 @@ pub fn init(dir: PathBuf, force_yes: bool) -> anyhow::Result<()> {
                 abi: Abi::default(),
                 interfaces: None,
                 kind: None,
+                bindings: None,
             }]),
             command: None,
         }
@@ -158,6 +159,7 @@ Press ^C at any time to quit."
                         abi: Abi::default(),
                         interfaces: None,
                         kind: None,
+                        bindings: None,
                     }
                 }
             };

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,7 +14,7 @@ pub static MAX_NAME_LENGTH: usize = 50;
 pub enum NameError {
     #[error("Please enter a name")]
     Empty,
-    #[error("The name \"{0}\" is too long. It must be {} characters or fewer")]
+    #[error("The name \"{0}\" is too long. It must be {1} characters or fewer")]
     NameTooLong(String, usize),
     #[error(
         "The name \"{0}\" contains invalid characters. Please use alpha-numeric characters, '-', and '_'",

--- a/wapm-toml/Cargo.toml
+++ b/wapm-toml/Cargo.toml
@@ -19,3 +19,6 @@ serde_cbor = "0.11.2"
 [features]
 integration_tests = []
 package = []
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/wapm-toml/Cargo.toml
+++ b/wapm-toml/Cargo.toml
@@ -11,7 +11,7 @@ serde_derive = "1.0"
 anyhow = "1"
 toml = "0.5.6"
 thiserror = "1.0"
-semver = { version = "0.11", features = ["serde"] }
+semver = { version = "1.0", features = ["serde"] }
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"
 serde_cbor = "0.11.2"

--- a/wapm-toml/src/lib.rs
+++ b/wapm-toml/src/lib.rs
@@ -309,22 +309,22 @@ pub struct Module {
     pub fs: Option<toml::value::Table>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interfaces: Option<HashMap<String, String>>,
-    pub exports: Option<Export>,
+    pub bindings: Option<Bindings>,
 }
 
 /// The interface exposed by a [`Module`].
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct Export {
+pub struct Bindings {
     /// The `*.wit` file's location on disk.
     pub wit: PathBuf,
     /// The version of the WIT format being used.
     pub wit_bindgen: Version,
 }
 
-impl Export {
+impl Bindings {
     /// Get all `*.wit` files that make up this interface.
     ///
-    /// This includes the [`Export::wit`] field, but also anything it may
+    /// This includes the [`Bindings::wit`] field, but also anything it may
     /// recursively depend on.
     pub fn referenced_files(&self, _base_directory: &Path) -> Vec<PathBuf> {
         // TODO: Parse `self.wit` to find any `*.wit` files we might
@@ -661,7 +661,7 @@ interfaces = {"wasi" = "0.0.0-unstable"}
 [[module]]
 name = "mod-with-exports"
 source = "target/wasm32-wasi/release/mod-with-exports.wasm"
-exports = { wit = "exports.wit", wit_bindgen = "0.0.0" }
+bindings = { wit = "exports.wit", wit_bindgen = "0.0.0" }
 
 [[command]]
 name = "command"
@@ -684,7 +684,7 @@ module = "mod"
                 interfaces: None,
                 #[cfg(feature = "package")]
                 fs: None,
-                exports: Some(Export {
+                bindings: Some(Bindings {
                     wit: PathBuf::from("exports.wit"),
                     wit_bindgen: "0.0.0".parse().unwrap()
                 }),

--- a/wapm-toml/src/lib.rs
+++ b/wapm-toml/src/lib.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 /// The ABI is a hint to WebAssembly runtimes about what additional imports to insert.
 /// It currently is only used for validation (in the validation subcommand).  The default value is `None`.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum Abi {
     #[serde(rename = "emscripten")]
     Emscripten,
@@ -31,7 +31,7 @@ impl Abi {
         }
     }
     pub fn is_none(&self) -> bool {
-        return self == &Abi::None;
+        self == &Abi::None
     }
     pub fn from_str(name: &str) -> Self {
         match name.to_lowercase().as_ref() {
@@ -58,7 +58,7 @@ impl Default for Abi {
 pub static MANIFEST_FILE_NAME: &str = "wapm.toml";
 pub static PACKAGES_DIR_NAME: &str = "wapm_packages";
 
-pub static README_PATHS: &[&'static str; 5] = &[
+pub static README_PATHS: &[&str; 5] = &[
     "README",
     "README.md",
     "README.markdown",
@@ -66,7 +66,7 @@ pub static README_PATHS: &[&'static str; 5] = &[
     "README.mkdn",
 ];
 
-pub static LICENSE_PATHS: &[&'static str; 3] = &["LICENSE", "LICENSE.md", "COPYING"];
+pub static LICENSE_PATHS: &[&str; 3] = &["LICENSE", "LICENSE.md", "COPYING"];
 
 /// Describes a command for a wapm module
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -211,7 +211,7 @@ pub fn toml_to_cbor_value(val: &toml::Value) -> serde_cbor::Value {
         toml::Value::Boolean(b) => serde_cbor::Value::Bool(*b),
         toml::Value::Datetime(d) => serde_cbor::Value::Text(format!("{}", d)),
         toml::Value::Array(sq) => {
-            serde_cbor::Value::Array(sq.into_iter().map(toml_to_cbor_value).collect())
+            serde_cbor::Value::Array(sq.iter().map(toml_to_cbor_value).collect())
         }
         toml::Value::Table(m) => serde_cbor::Value::Map(
             m.iter()
@@ -238,7 +238,7 @@ pub fn json_to_cbor_value(val: &serde_json::Value) -> serde_cbor::Value {
         }
         serde_json::Value::String(s) => serde_cbor::Value::Text(s.clone()),
         serde_json::Value::Array(sq) => {
-            serde_cbor::Value::Array(sq.into_iter().map(json_to_cbor_value).collect())
+            serde_cbor::Value::Array(sq.iter().map(json_to_cbor_value).collect())
         }
         serde_json::Value::Object(m) => serde_cbor::Value::Map(
             m.iter()
@@ -265,7 +265,7 @@ pub fn yaml_to_cbor_value(val: &serde_yaml::Value) -> serde_cbor::Value {
         }
         serde_yaml::Value::String(s) => serde_cbor::Value::Text(s.clone()),
         serde_yaml::Value::Sequence(sq) => {
-            serde_cbor::Value::Array(sq.into_iter().map(yaml_to_cbor_value).collect())
+            serde_cbor::Value::Array(sq.iter().map(yaml_to_cbor_value).collect())
         }
         serde_yaml::Value::Mapping(m) => serde_cbor::Value::Map(
             m.iter()
@@ -283,7 +283,7 @@ pub enum CommandAnnotations {
     Raw(toml::Value),
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct FileCommandAnnotations {
     pub file: PathBuf,
     pub kind: FileKind,
@@ -297,7 +297,7 @@ pub enum FileKind {
     Json,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Module {
     pub name: String,
     pub source: PathBuf,
@@ -313,7 +313,7 @@ pub struct Module {
 }
 
 /// The interface exposed by a [`Module`].
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Bindings {
     /// The `*.wit` file's location on disk.
     pub wit: PathBuf,
@@ -430,7 +430,7 @@ impl Manifest {
 
         if let Some(ref commands) = self.command {
             for command in commands {
-                if let Some(ref module) = module_map.get(&command.get_module()) {
+                if let Some(module) = module_map.get(&command.get_module()) {
                     if module.abi == Abi::None && module.interfaces.is_none() {
                         return Err(ManifestError::ValidationError(ValidationError::MissingABI(
                             command.get_name(),

--- a/wapm-toml/src/lib.rs
+++ b/wapm-toml/src/lib.rs
@@ -324,7 +324,7 @@ pub struct Export {
 impl Export {
     /// Get all `*.wit` files that make up this interface.
     ///
-    /// This includes the [`Exports::wit`] field, but also anything it may
+    /// This includes the [`Export::wit`] field, but also anything it may
     /// recursively depend on.
     pub fn referenced_files(&self, _base_directory: &Path) -> Vec<PathBuf> {
         // TODO: Parse `self.wit` to find any `*.wit` files we might

--- a/wapm-toml/src/lib.rs
+++ b/wapm-toml/src/lib.rs
@@ -321,6 +321,20 @@ pub struct Export {
     pub wit_bindgen: Version,
 }
 
+impl Export {
+    /// Get all `*.wit` files that make up this interface.
+    ///
+    /// This includes the [`Exports::wit`] field, but also anything it may
+    /// recursively depend on.
+    pub fn referenced_files(&self, _base_directory: &Path) -> Vec<PathBuf> {
+        // TODO: Parse `self.wit` to find any `*.wit` files we might
+        // transitively depend on and resolve them relative to self.wit's
+        // parent directory.
+        //
+        // For now, any `*.wit` files that import other files will error out
+        // further down the track.
+        vec![self.wit.clone()]
+    }
 }
 
 /// The manifest represents the file used to describe a Wasm package.


### PR DESCRIPTION
I've pushed the code from #250 to a branch on the `wasmerio/wapm-cli` repo instead of my fork.

CC: #248.