### PR TITLE
Validate that bindings files exist

### DIFF
--- a/wapm-toml/src/lib.rs
+++ b/wapm-toml/src/lib.rs
@@ -327,14 +327,17 @@ impl Bindings {
     ///
     /// This includes the [`Bindings::wit`] field, but also anything it may
     /// recursively depend on.
-    pub fn referenced_files(&self, _base_directory: &Path) -> Vec<PathBuf> {
+    pub fn referenced_files(&self, base_directory: &Path) -> Vec<PathBuf> {
         // TODO: Parse `self.wit` to find any `*.wit` files we might
         // transitively depend on and resolve them relative to self.wit's
         // parent directory.
         //
         // For now, any `*.wit` files that import other files will error out
         // further down the track.
-        vec![self.wit_exports.clone()]
+
+        // Note: Joining with an absolute path will just use that path, so no
+        // need for checking if wit_exports.is_absolute()
+        vec![base_directory.join(&self.wit_exports)]
     }
 }
 


### PR DESCRIPTION
Make sure each bindings file exists when people run `wapm validate path/to/package`.