### PR TITLE
Add a task to automatically update the GraphQL schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,3 +106,6 @@ regression-tests:
 	chmod +x end-to-end-tests/ci/init-and-add.sh
 	./end-to-end-tests/ci/init-and-add.sh
 	chmod -x end-to-end-tests/ci/init-and-add.sh
+
+update-schema:
+	curl --fail "$(shell wapm config get registry.url)/schema.graphql" > graphql/schema.graphql

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,318 +1,303 @@
-type APIToken {
-  createdAt: DateTime!
+interface Node {
+  """The ID of the object"""
   id: ID!
-  identifier: String
-  lastUsedAt: DateTime
+}
+
+type PublicKey implements Node {
+  """The ID of the object"""
+  id: ID!
+  owner: User!
+  keyId: String!
+  key: String!
   revokedAt: DateTime
-  user: User!
+  uploadedAt: DateTime!
+  verifyingSignature: Signature
+  revoked: Boolean!
 }
 
-type APITokenConnection {
-  # Contains the nodes in this connection.
-  edges: [APITokenEdge]!
+type User implements Node & PackageOwner {
+  """Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."""
+  username: String!
+  firstName: String!
+  lastName: String!
+  email: String!
+  dateJoined: DateTime!
+  isEmailValidated: Boolean!
+  bio: String
+  location: String
+  websiteUrl: String
 
-  # Pagination data for this connection.
+  """The ID of the object"""
+  id: ID!
+  globalName: String!
+  avatar(size: Int = 80): String!
+  isViewer: Boolean!
+  hasUsablePassword: Boolean
+  fullName: String!
+  githubUrl: String
+  twitterUrl: String
+  publicActivity(before: String, after: String, first: Int, last: Int): ActivityEventConnection!
+  namespaces(before: String, after: String, first: Int, last: Int): NamespaceConnection!
+  packages(collaborating: Boolean = false, before: String, after: String, first: Int, last: Int): PackageConnection!
+  packageVersions(before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+  packageTransfersIncoming(before: String, after: String, first: Int, last: Int): PackageTransferRequestConnection!
+  packageInvitesIncoming(before: String, after: String, first: Int, last: Int): PackageCollaboratorInviteConnection!
+  namespaceInvitesIncoming(before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
+  apiTokens(before: String, after: String, first: Int, last: Int): APITokenConnection!
+  notifications(before: String, after: String, first: Int, last: Int): UserNotificationConnection!
+}
+
+interface PackageOwner {
+  globalName: String!
+}
+
+"""
+The `DateTime` scalar type represents a DateTime
+value as specified by
+[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
+"""
+scalar DateTime
+
+type ActivityEventConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [ActivityEventEdge]!
 }
 
-# A Relay edge containing a `APIToken` and its cursor.
-type APITokenEdge {
-  # A cursor for use in pagination
+"""
+The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+"""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+}
+
+"""A Relay edge containing a `ActivityEvent` and its cursor."""
+type ActivityEventEdge {
+  """The item at the end of the edge"""
+  node: ActivityEvent
+
+  """A cursor for use in pagination"""
   cursor: String!
-
-  # The item at the end of the edge
-  node: APIToken
-}
-
-input AcceptNamespaceCollaboratorInviteInput {
-  clientMutationId: String
-  inviteId: ID!
-}
-
-type AcceptNamespaceCollaboratorInvitePayload {
-  clientMutationId: String
-  namespaceCollaboratorInvite: NamespaceCollaboratorInvite!
-}
-
-input AcceptPackageCollaboratorInviteInput {
-  clientMutationId: String
-  inviteId: ID!
-}
-
-type AcceptPackageCollaboratorInvitePayload {
-  clientMutationId: String
-  packageCollaboratorInvite: PackageCollaboratorInvite!
-}
-
-input AcceptPackageTransferRequestInput {
-  clientMutationId: String
-  packageTransferRequestId: ID!
-}
-
-type AcceptPackageTransferRequestPayload {
-  clientMutationId: String
-  package: Package!
-  packageTransferRequest: PackageTransferRequest!
 }
 
 type ActivityEvent implements Node {
-  actorIcon: String!
-  body: ActivityEventBody!
-  createdAt: DateTime!
-
-  # The ID of the object
+  """The ID of the object"""
   id: ID!
+  body: ActivityEventBody!
+  actorIcon: String!
+  createdAt: DateTime!
 }
 
 type ActivityEventBody {
-  ranges: [NodeBodyRange!]!
   text: String!
+  ranges: [NodeBodyRange!]!
 }
 
-type ActivityEventConnection {
-  # Contains the nodes in this connection.
-  edges: [ActivityEventEdge]!
+type NodeBodyRange {
+  entity: Node!
+  offset: Int!
+  length: Int!
+}
 
-  # Pagination data for this connection.
+type NamespaceConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [NamespaceEdge]!
 }
 
-# A Relay edge containing a `ActivityEvent` and its cursor.
-type ActivityEventEdge {
-  # A cursor for use in pagination
+"""A Relay edge containing a `Namespace` and its cursor."""
+type NamespaceEdge {
+  """The item at the end of the edge"""
+  node: Namespace
+
+  """A cursor for use in pagination"""
   cursor: String!
-
-  # The item at the end of the edge
-  node: ActivityEvent
 }
 
-input ArchivePackageInput {
-  clientMutationId: String
-  packageId: ID!
-}
-
-type ArchivePackagePayload {
-  clientMutationId: String
-  package: Package!
-}
-
-input ChangePackageVersionArchivedStatusInput {
-  clientMutationId: String
-  isArchived: Boolean
-  packageVersionId: ID!
-}
-
-type ChangePackageVersionArchivedStatusPayload {
-  clientMutationId: String
-  packageVersion: PackageVersion!
-}
-
-input ChangeUserEmailInput {
-  clientMutationId: String
-  newEmail: String!
-}
-
-type ChangeUserEmailPayload {
-  clientMutationId: String
-  user: User!
-}
-
-input ChangeUserPasswordInput {
-  clientMutationId: String
-  password: String!
-
-  # The token associated to change the password. If not existing it will use the request user by default
-  token: String
-}
-
-type ChangeUserPasswordPayload {
-  clientMutationId: String
-  token: String
-}
-
-input ChangeUserUsernameInput {
-  clientMutationId: String
-
-  # The new user username
-  username: String!
-}
-
-type ChangeUserUsernamePayload {
-  clientMutationId: String
-  token: String
-  user: User
-}
-
-input CheckUserExistsInput {
-  clientMutationId: String
-
-  # The user
-  user: String!
-}
-
-type CheckUserExistsPayload {
-  clientMutationId: String
-  exists: Boolean!
-
-  # The user is only returned if the user input was the username
-  user: User
-}
-
-type Command {
-  command: String!
-  module: PackageVersionModule!
-  packageVersion: PackageVersion!
-}
-
-input CreateNamespaceInput {
-  # The namespace avatar
-  avatar: String
-  clientMutationId: String
-
-  # The namespace description
-  description: String
-
-  # The namespace display name
+type Namespace implements Node & PackageOwner {
+  """The ID of the object"""
+  id: ID!
+  name: String!
   displayName: String
-  name: String!
-}
-
-type CreateNamespacePayload {
-  clientMutationId: String
-  namespace: Namespace!
-  user: User!
-}
-
-# The `DateTime` scalar type represents a DateTime
-# value as specified by
-# [iso8601](https://en.wikipedia.org/wiki/ISO_8601).
-scalar DateTime
-
-input DeleteNamespaceInput {
-  clientMutationId: String
-  namespaceId: ID!
-}
-
-type DeleteNamespacePayload {
-  clientMutationId: String
-  success: Boolean!
-}
-
-type ErrorType {
-  field: String!
-  messages: [String!]!
-}
-
-input GenerateAPITokenInput {
-  clientMutationId: String
-  identifier: String
-}
-
-type GenerateAPITokenPayload {
-  clientMutationId: String
-  token: APIToken
-  tokenRaw: String
-  user: User
-}
-
-# The `GenericScalar` scalar type represents a generic
-# GraphQL scalar value that could be:
-# String, Boolean, Int, Float, List or Object.
-scalar GenericScalar
-
-type GetPasswordResetToken {
-  user: User
-  valid: Boolean!
-}
-
-union GlobalObject = Namespace | User
-
-input InputSignature {
-  data: String!
-  publicKeyKeyId: String!
-}
-
-type Interface implements Node {
-  createdAt: DateTime!
   description: String!
-  displayName: String!
-  homepage: String
-  icon: String
-
-  # The ID of the object
-  id: ID!
-  lastVersion: InterfaceVersion
-  name: String!
-  updatedAt: DateTime!
-  versions(after: String = null, before: String = null, first: Int = null, last: Int = null, offset: Int = null): InterfaceVersionConnection!
-}
-
-type InterfaceVersion implements Node {
-  content: String!
+  avatar: String!
+  avatarUpdatedAt: DateTime
   createdAt: DateTime!
-
-  # The ID of the object
-  id: ID!
-  interface: Interface!
-  packageVersions(after: String = null, before: String = null, first: Int = null, last: Int = null, offset: Int = null): PackageVersionConnection!
-  publishedBy: User!
   updatedAt: DateTime!
-  version: String!
+  maintainerInvites(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
+  userSet(offset: Int, before: String, after: String, first: Int, last: Int): UserConnection!
+  globalName: String!
+  packages(before: String, after: String, first: Int, last: Int): PackageConnection!
+  packageVersions(before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+  collaborators(before: String, after: String, first: Int, last: Int): NamespaceCollaboratorConnection!
+  publicActivity(before: String, after: String, first: Int, last: Int): ActivityEventConnection!
+  pendingInvites(before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
+  viewerHasRole(role: Role!): Boolean!
+  packageTransfersIncoming(before: String, after: String, first: Int, last: Int): PackageTransferRequestConnection!
 }
 
-type InterfaceVersionConnection {
-  # Contains the nodes in this connection.
-  edges: [InterfaceVersionEdge]!
-
-  # Pagination data for this connection.
+type NamespaceCollaboratorInviteConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [NamespaceCollaboratorInviteEdge]!
 }
 
-# A Relay edge containing a `InterfaceVersion` and its cursor.
-type InterfaceVersionEdge {
-  # A cursor for use in pagination
+"""
+A Relay edge containing a `NamespaceCollaboratorInvite` and its cursor.
+"""
+type NamespaceCollaboratorInviteEdge {
+  """The item at the end of the edge"""
+  node: NamespaceCollaboratorInvite
+
+  """A cursor for use in pagination"""
   cursor: String!
-
-  # The item at the end of the edge
-  node: InterfaceVersion
 }
 
-input InviteNamespaceCollaboratorInput {
-  clientMutationId: String
-  email: String
-  namespaceId: ID!
-  role: Role!
-  username: String
-}
-
-type InviteNamespaceCollaboratorPayload {
-  clientMutationId: String
-  invite: NamespaceCollaboratorInvite!
+type NamespaceCollaboratorInvite implements Node {
+  """The ID of the object"""
+  id: ID!
+  requestedBy: User!
+  user: User
+  inviteEmail: String
   namespace: Namespace!
+  role: RegistryNamespaceMaintainerInviteRoleChoices!
+  accepted: NamespaceCollaborator
+  approvedBy: User
+  declinedBy: User
+  createdAt: DateTime!
+  expiresAt: DateTime!
+  closedAt: DateTime
 }
 
-input InvitePackageCollaboratorInput {
-  clientMutationId: String
-  email: String
+"""An enumeration."""
+enum RegistryNamespaceMaintainerInviteRoleChoices {
+  """Admin"""
+  ADMIN
+
+  """Editor"""
+  EDITOR
+
+  """Viewer"""
+  VIEWER
+}
+
+type NamespaceCollaborator implements Node {
+  """The ID of the object"""
+  id: ID!
+  user: User!
+  role: RegistryNamespaceMaintainerRoleChoices!
+  namespace: Namespace!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  invite: NamespaceCollaboratorInvite
+}
+
+"""An enumeration."""
+enum RegistryNamespaceMaintainerRoleChoices {
+  """Admin"""
+  ADMIN
+
+  """Editor"""
+  EDITOR
+
+  """Viewer"""
+  VIEWER
+}
+
+type UserConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [UserEdge]!
+}
+
+"""A Relay edge containing a `User` and its cursor."""
+type UserEdge {
+  """The item at the end of the edge"""
+  node: User
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type PackageConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageEdge]!
+}
+
+"""A Relay edge containing a `Package` and its cursor."""
+type PackageEdge {
+  """The item at the end of the edge"""
+  node: Package
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type Package implements Likeable & Node & PackageOwner {
+  """The ID of the object"""
+  id: ID!
+  name: String!
+  namespace: String
+  private: Boolean!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  maintainers: [User]! @deprecated(reason: "Please use collaborators instead")
+  curated: Boolean!
+  ownerObjectId: Int!
+  lastVersion: PackageVersion
+
+  """The app icon. It should be formatted in the same way as Apple icons"""
+  icon: String!
+  iconUpdatedAt: DateTime
+  watchersCount: Int!
+  versions: [PackageVersion]!
+  collectionSet: [Collection!]!
+  likersCount: Int!
+  viewerHasLiked: Boolean!
+  globalName: String!
+  alias: String
+  displayName: String!
+
+  """The name of the package without the owner"""
   packageName: String!
-  role: Role!
-  username: String
-}
 
-type InvitePackageCollaboratorPayload {
-  clientMutationId: String
-  invite: PackageCollaboratorInvite!
-  package: Package!
-}
+  """The app icon. It should be formatted in the same way as Apple icons"""
+  appIcon: String! @deprecated(reason: "Please use icon instead")
 
-input LikePackageInput {
-  clientMutationId: String
-  packageId: ID!
-}
+  """The total number of downloads of the package"""
+  downloadsCount: Int
 
-type LikePackagePayload {
-  clientMutationId: String
-  package: Package!
+  """The public keys for all the published versions"""
+  publicKeys: [PublicKey!]!
+  collaborators(before: String, after: String, first: Int, last: Int): PackageCollaboratorConnection!
+  pendingInvites(before: String, after: String, first: Int, last: Int): PackageCollaboratorInviteConnection!
+  viewerHasRole(role: Role!): Boolean!
+  owner: PackageOwner!
+  isTransferring: Boolean!
+  activeTransferRequest: PackageTransferRequest
+  isArchived: Boolean!
+  viewerIsWatching: Boolean!
 }
 
 interface Likeable {
@@ -321,721 +306,381 @@ interface Likeable {
   viewerHasLiked: Boolean!
 }
 
-type Mutation {
-  acceptNamespaceCollaboratorInvite(input: AcceptNamespaceCollaboratorInviteInput!): AcceptNamespaceCollaboratorInvitePayload
-  acceptPackageCollaboratorInvite(input: AcceptPackageCollaboratorInviteInput!): AcceptPackageCollaboratorInvitePayload
-  acceptPackageTransferRequest(input: AcceptPackageTransferRequestInput!): AcceptPackageTransferRequestPayload
-  archivePackage(input: ArchivePackageInput!): ArchivePackagePayload
-  changePackageVersionArchivedStatus(input: ChangePackageVersionArchivedStatusInput!): ChangePackageVersionArchivedStatusPayload
-  changeUserEmail(input: ChangeUserEmailInput!): ChangeUserEmailPayload
-  changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordPayload
-  changeUserUsername(input: ChangeUserUsernameInput!): ChangeUserUsernamePayload
-  checkUserExists(input: CheckUserExistsInput!): CheckUserExistsPayload
-  createNamespace(input: CreateNamespaceInput!): CreateNamespacePayload
-  deleteNamespace(input: DeleteNamespaceInput!): DeleteNamespacePayload
-  generateApiToken(input: GenerateAPITokenInput!): GenerateAPITokenPayload
-  inviteNamespaceCollaborator(input: InviteNamespaceCollaboratorInput!): InviteNamespaceCollaboratorPayload
-  invitePackageCollaborator(input: InvitePackageCollaboratorInput!): InvitePackageCollaboratorPayload
-  likePackage(input: LikePackageInput!): LikePackagePayload
-  publishPackage(input: PublishPackageInput!): PublishPackagePayload
-  publishPublicKey(input: PublishPublicKeyInput!): PublishPublicKeyPayload
-  readNotification(input: ReadNotificationInput!): ReadNotificationPayload
-  refreshToken(input: RefreshInput!): RefreshPayload
-  registerUser(input: RegisterUserInput!): RegisterUserPayload
-  removeNamespaceCollaborator(input: RemoveNamespaceCollaboratorInput!): RemoveNamespaceCollaboratorPayload
-  removeNamespaceCollaboratorInvite(input: RemoveNamespaceCollaboratorInviteInput!): RemoveNamespaceCollaboratorInvitePayload
-  removePackageCollaborator(input: RemovePackageCollaboratorInput!): RemovePackageCollaboratorPayload
-  removePackageCollaboratorInvite(input: RemovePackageCollaboratorInviteInput!): RemovePackageCollaboratorInvitePayload
-  removePackageTransferRequest(input: RemovePackageTransferRequestInput!): RemovePackageTransferRequestPayload
-  requestPackageTransfer(input: RequestPackageTransferInput!): RequestPackageTransferPayload
-  requestPasswordReset(input: RequestPasswordResetInput!): RequestPasswordResetPayload
-  requestValidationEmail(input: RequestValidationEmailInput!): RequestValidationEmailPayload
-  revokeApiToken(input: RevokeAPITokenInput!): RevokeAPITokenPayload
-  seePendingNotifications(input: SeePendingNotificationsInput!): SeePendingNotificationsPayload
-
-  # Social Auth for JSON Web Token (JWT)
-  socialAuth(input: SocialAuthJWTInput!): SocialAuthJWTPayload
-
-  # Obtain JSON Web Token mutation
-  tokenAuth(input: ObtainJSONWebTokenInput!): ObtainJSONWebTokenPayload
-  unlikePackage(input: UnlikePackageInput!): UnlikePackagePayload
-  unwatchPackage(input: UnwatchPackageInput!): UnwatchPackagePayload
-  updateNamespace(input: UpdateNamespaceInput!): UpdateNamespacePayload
-  updateNamespaceCollaboratorRole(input: UpdateNamespaceCollaboratorRoleInput!): UpdateNamespaceCollaboratorRolePayload
-  updatePackage(input: UpdatePackageInput!): UpdatePackagePayload
-  updatePackageCollaboratorRole(input: UpdatePackageCollaboratorRoleInput!): UpdatePackageCollaboratorRolePayload
-  updateUserInfo(input: UpdateUserInfoInput!): UpdateUserInfoPayload
-  validateUserEmail(input: ValidateUserEmailInput!): ValidateUserEmailPayload
-  validateUserPassword(input: ValidateUserPasswordInput!): ValidateUserPasswordPayload
-  verifyToken(input: VerifyInput!): VerifyPayload
-  watchPackage(input: WatchPackageInput!): WatchPackagePayload
-}
-
-type Namespace implements Node & PackageOwner {
-  avatar: String!
-  avatarUpdatedAt: DateTime
-  collaborators(after: String = null, before: String = null, first: Int = null, last: Int = null): NamespaceCollaboratorConnection
-  createdAt: DateTime!
+type PackageVersion implements Node {
+  """The ID of the object"""
+  id: ID!
+  package: Package!
+  version: String!
   description: String!
-  displayName: String
-  globalName: String!
+  manifest: String!
+  license: String
+  licenseFile: String
+  readme: String
+  witMd: String
+  repository: String
+  homepage: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  staticObjectsCompiled: Boolean!
+  nativeExecutablesCompiled: Boolean!
+  publishedBy: User!
+  signature: Signature
+  isArchived: Boolean!
+  file: String!
 
-  # The ID of the object
-  id: ID!
-  maintainerInvites: [NamespaceCollaboratorInvite!]!
-  maintainersWithRoles(after: String = null, before: String = null, first: Int = null, last: Int = null, offset: Int = null): NamespaceMaintainerConnection!
+  """"""
+  fileSize: BigInt!
+  piritaFile: String
+
+  """"""
+  piritaFileSize: BigInt!
+  piritaManifest: JSONString
+  piritaVolumes: JSONString
+  hasBindings: Boolean!
+  lastversionPackage(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+  commands: [Command!]!
+  nativeexecutableSet(offset: Int, before: String, after: String, first: Int, last: Int): NativeExecutableConnection!
+  javascriptlanguagebindingSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionNPMBindingConnection!
+  pythonlanguagebindingSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionPythonBindingConnection!
+  distribution: PackageDistribution!
+  filesystem: [PackageVersionFilesystem]!
+  isLastVersion: Boolean!
+  witFile: String
+  isSigned: Boolean!
+  moduleInterfaces: [InterfaceVersion!]!
+  modules: [PackageVersionModule!]!
+  getPiritaContents(volume: String! = "atom", root: String! = ""): [PiritaFilesystemItem!]!
+  nativeExecutables(triple: String, wasmerCompilerVersion: String): [NativeExecutable]
+  bindings: [PackageVersionLanguageBinding]!
+  npmBindings: PackageVersionNPMBinding
+  pythonBindings: PackageVersionPythonBinding
+}
+
+"""
+The `BigInt` scalar type represents non-fractional whole numeric values.
+`BigInt` is not constrained to 32-bit like the `Int` type and thus is a less
+compatible type.
+"""
+scalar BigInt
+
+"""
+Allows use of a JSON String for input / output from the GraphQL schema.
+
+Use of this type is *not recommended* as you lose the benefits of having a defined, static
+schema (one of the key benefits of GraphQL).
+"""
+scalar JSONString
+
+type Command {
+  command: String!
+  packageVersion: PackageVersion!
+  module: PackageVersionModule!
+}
+
+type PackageVersionModule {
   name: String!
-  packageVersions(after: String = null, before: String = null, first: Int = null, last: Int = null): PackageVersionConnection
-  packages(after: String = null, before: String = null, first: Int = null, last: Int = null): PackageConnection
-  pendingInvites(after: String = null, before: String = null, first: Int = null, last: Int = null): NamespaceCollaboratorInviteConnection
-  publicActivity(after: String = null, before: String = null, first: Int = null, last: Int = null): ActivityEventConnection!
-  updatedAt: DateTime!
-  userSet(after: String = null, before: String = null, first: Int = null, last: Int = null, offset: Int = null): UserConnection!
-  viewerHasRole(role: Role!): Boolean!
+  source: String!
+  abi: String
+  publicUrl: String!
 }
 
-type NamespaceCollaborator {
-  createdAt: DateTime!
-  id: ID!
-  invite: NamespaceCollaboratorInvite
-  namespace: Namespace!
-  role: RegistryNamespaceMaintainerRoleChoices!
-  updatedAt: DateTime!
-  user: User!
-}
-
-type NamespaceCollaboratorConnection {
-  # Contains the nodes in this connection.
-  edges: [NamespaceCollaboratorEdge]!
-
-  # Pagination data for this connection.
+type NativeExecutableConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [NativeExecutableEdge]!
 }
 
-# A Relay edge containing a `NamespaceCollaborator` and its cursor.
-type NamespaceCollaboratorEdge {
-  # A cursor for use in pagination
+"""A Relay edge containing a `NativeExecutable` and its cursor."""
+type NativeExecutableEdge {
+  """The item at the end of the edge"""
+  node: NativeExecutable
+
+  """A cursor for use in pagination"""
   cursor: String!
-
-  # The item at the end of the edge
-  node: NamespaceCollaborator
 }
 
-type NamespaceCollaboratorInvite {
-  accepted: NamespaceMaintainer
-  approvedBy: User
-  closedAt: DateTime
-  createdAt: DateTime!
-  declinedBy: User
-  expiresAt: DateTime!
+type NativeExecutable implements Node {
+  """The ID of the object"""
   id: ID!
-  inviteEmail: String
-  namespace: Namespace!
-  requestedBy: User!
-  role: RegistryNamespaceMaintainerInviteRoleChoices!
-  user: User
+  module: String! @deprecated(reason: "Use filename instead")
+  filename: String!
+  targetTriple: String!
+  downloadUrl: String!
 }
 
-type NamespaceCollaboratorInviteConnection {
-  # Contains the nodes in this connection.
-  edges: [NamespaceCollaboratorInviteEdge]!
-
-  # Pagination data for this connection.
+type PackageVersionNPMBindingConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageVersionNPMBindingEdge]!
 }
 
-# A Relay edge containing a `NamespaceCollaboratorInvite` and its cursor.
-type NamespaceCollaboratorInviteEdge {
-  # A cursor for use in pagination
+"""A Relay edge containing a `PackageVersionNPMBinding` and its cursor."""
+type PackageVersionNPMBindingEdge {
+  """The item at the end of the edge"""
+  node: PackageVersionNPMBinding
+
+  """A cursor for use in pagination"""
   cursor: String!
-
-  # The item at the end of the edge
-  node: NamespaceCollaboratorInvite
 }
 
-type NamespaceConnection {
-  # Contains the nodes in this connection.
-  edges: [NamespaceEdge]!
+type PackageVersionNPMBinding implements PackageVersionLanguageBinding & Node {
+  """The ID of the object"""
+  id: ID!
+  language: ProgrammingLanguage!
 
-  # Pagination data for this connection.
-  pageInfo: PageInfo!
-}
+  """The URL of the generated artifacts on WAPM's CDN."""
+  url: String!
 
-# A Relay edge containing a `Namespace` and its cursor.
-type NamespaceEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: Namespace
-}
-
-type NamespaceMaintainer implements Node {
+  """When the binding was generated"""
   createdAt: DateTime!
-
-  # The ID of the object
-  id: ID!
-  invite: NamespaceCollaboratorInvite
-  namespace: Namespace!
-  role: RegistryNamespaceMaintainerRoleChoices!
-  updatedAt: DateTime!
-  user: User!
-}
-
-type NamespaceMaintainerConnection {
-  # Contains the nodes in this connection.
-  edges: [NamespaceMaintainerEdge]!
-
-  # Pagination data for this connection.
-  pageInfo: PageInfo!
-}
-
-# A Relay edge containing a `NamespaceMaintainer` and its cursor.
-type NamespaceMaintainerEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: NamespaceMaintainer
-}
-
-# An object with an ID
-interface Node {
-  # The ID of the object
-  id: ID!
-}
-
-type NodeBodyRange {
-  entity: Node!
-  length: Int!
-  offset: Int!
-}
-
-input ObtainJSONWebTokenInput {
-  clientMutationId: String
-  password: String!
-  username: String!
-}
-
-# Obtain JSON Web Token mutation
-type ObtainJSONWebTokenPayload {
-  clientMutationId: String
-  payload: GenericScalar!
-  refreshExpiresIn: Int!
-  refreshToken: String!
-  token: String!
-}
-
-type Package implements Likeable & Node & PackageOwner {
-  alias: String
-
-  # The app icon. It should be formatted in the same way as Apple icons
-  appIcon: String! @deprecated(reason: "Please use icon instead")
-  collaborators(after: String = null, before: String = null, first: Int = null, last: Int = null): PackageCollaboratorConnection
-  createdAt: DateTime!
-  curated: Boolean!
-  displayName: String!
-
-  # The total number of downloads of the package
-  downloadsCount: Int
-  globalName: String!
-
-  # The app icon. It should be formatted in the same way as Apple icons
-  icon: String!
-  iconUpdatedAt: DateTime
-
-  # The ID of the object
-  id: ID!
-  isTransferring: Boolean!
-  lastVersion: PackageVersion
-  likeCount: Int!
-  likersCount: Int!
-  maintainers: [User]! @deprecated(reason: "Please use collaborators instead")
-  name: String!
-  namespace: String
-  owner: PackageOwner
-  ownerObjectId: Int!
-
-  # The name of the package without the owner
+  generator: PackageVersion!
+  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  npmDefaultInstallPackageName(url: String): String! @deprecated(reason: "Please use packageName instead")
   packageName: String!
-  pendingInvites(after: String = null, before: String = null, first: Int = null, last: Int = null): PackageCollaboratorInviteConnection
-  private: Boolean!
-
-  # The public keys for all the published versions
-  publicKeys: [PublicKey!]!
-  updatedAt: DateTime!
-  versions: [PackageVersion]
-  viewerHasLiked: Boolean!
-  viewerHasRole(role: Role!): Boolean!
-  viewerIsWatching: Boolean!
-  watchCount: Int!
 }
 
-type PackageCollaborator implements Node {
-  createdAt: DateTime!
-
-  # The ID of the object
+interface PackageVersionLanguageBinding {
   id: ID!
-  invite: PackageCollaboratorInvite
-  package: Package!
-  role: RegistryPackageMaintainerRoleChoices!
-  updatedAt: DateTime!
-  user: User!
-}
+  language: ProgrammingLanguage!
 
-type PackageCollaboratorConnection {
-  # Contains the nodes in this connection.
-  edges: [PackageCollaboratorEdge]!
+  """The URL of the generated artifacts on WAPM's CDN."""
+  url: String!
 
-  # Pagination data for this connection.
-  pageInfo: PageInfo!
-}
-
-# A Relay edge containing a `PackageCollaborator` and its cursor.
-type PackageCollaboratorEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: PackageCollaborator
-}
-
-type PackageCollaboratorInvite implements Node {
-  accepted: PackageCollaborator
-  approvedBy: User
-  closedAt: DateTime
+  """When the binding was generated"""
   createdAt: DateTime!
-  declinedBy: User
-  expiresAt: DateTime!
-
-  # The ID of the object
-  id: ID!
-  inviteEmail: String
-  package: Package!
-  requestedBy: User!
-  role: RegistryPackageMaintainerInviteRoleChoices!
-  user: User
+  generator: PackageVersion!
+  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
 }
 
-type PackageCollaboratorInviteConnection {
-  # Contains the nodes in this connection.
-  edges: [PackageCollaboratorInviteEdge]!
+enum ProgrammingLanguage {
+  PYTHON
+  JAVASCRIPT
+}
 
-  # Pagination data for this connection.
+type PackageVersionPythonBindingConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageVersionPythonBindingEdge]!
 }
 
-# A Relay edge containing a `PackageCollaboratorInvite` and its cursor.
-type PackageCollaboratorInviteEdge {
-  # A cursor for use in pagination
+"""
+A Relay edge containing a `PackageVersionPythonBinding` and its cursor.
+"""
+type PackageVersionPythonBindingEdge {
+  """The item at the end of the edge"""
+  node: PackageVersionPythonBinding
+
+  """A cursor for use in pagination"""
   cursor: String!
-
-  # The item at the end of the edge
-  node: PackageCollaboratorInvite
 }
 
-type PackageConnection {
-  # Contains the nodes in this connection.
-  edges: [PackageEdge]!
+type PackageVersionPythonBinding implements PackageVersionLanguageBinding & Node {
+  """The ID of the object"""
+  id: ID!
+  language: ProgrammingLanguage!
 
-  # Pagination data for this connection.
-  pageInfo: PageInfo!
+  """The URL of the generated artifacts on WAPM's CDN."""
+  url: String!
+
+  """When the binding was generated"""
+  createdAt: DateTime!
+  generator: PackageVersion!
+  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  packageName: String!
+  pythonDefaultInstallPackageName(url: String): String!
 }
 
 type PackageDistribution {
   downloadUrl: String!
   size: Int!
-}
-
-# A Relay edge containing a `Package` and its cursor.
-type PackageEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: Package
-}
-
-interface PackageOwner {
-  globalName: String!
-}
-
-type PackageTransferRequest implements Node {
-  approvedBy: User
-  closedAt: DateTime
-  createdAt: DateTime!
-  declinedBy: User
-  expiresAt: DateTime!
-
-  # The ID of the object
-  id: ID!
-  newOwnerObjectId: Int!
-  package: Package!
-  previousOwnerObjectId: Int!
-  requestedBy: User!
-}
-
-type PackageTransferRequestConnection {
-  # Contains the nodes in this connection.
-  edges: [PackageTransferRequestEdge]!
-
-  # Pagination data for this connection.
-  pageInfo: PageInfo!
-}
-
-# A Relay edge containing a `PackageTransferRequest` and its cursor.
-type PackageTransferRequestEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: PackageTransferRequest
-}
-
-type PackageVersion implements Node {
-  bindings: [PackageVersionBinding]!
-  commands: [Command!]!
-  createdAt: DateTime!
-  description: String!
-  distribution: PackageDistribution!
-  file: String!
-  fileSize: Int!
-  filesystem: [PackageVersionFilesystem]!
-  homepage: String
-
-  # The ID of the object
-  id: ID!
-  isArchived: Boolean!
-  isLastVersion: Boolean!
-  isSigned: Boolean!
-  license: String
-  licenseFile: String
-  manifest: String!
-  moduleInterfaces: [InterfaceVersion!]!
-  modules: [PackageVersionModule!]!
-  package: Package!
-  publishedBy: User!
-  readme: String
-  repository: String
-  signature: Signature
-  updatedAt: DateTime!
-  version: String!
-}
-
-interface PackageVersionBinding {
-  # The module these bindings are associated with.
-  module: String!
-}
-
-type PackageVersionNPMBinding implements PackageVersionBinding {
-  npmDefaultInstallPackageName: String!
-}
-
-type PackageVersionPythonBinding implements PackageVersionBinding {
-  pythonDefaultInstallPackageName: String!
-}
-
-type PackageVersionConnection {
-  # Contains the nodes in this connection.
-  edges: [PackageVersionEdge]!
-
-  # Pagination data for this connection.
-  pageInfo: PageInfo!
-}
-
-# A Relay edge containing a `PackageVersion` and its cursor.
-type PackageVersionEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: PackageVersion
+  piritaDownloadUrl: String
+  piritaSize: Int!
 }
 
 type PackageVersionFilesystem {
-  host: String!
   wasm: String!
+  host: String!
 }
 
-type PackageVersionModule {
-  abi: String
-  name: String!
-  publicUrl: String!
-  source: String!
-}
-
-# The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
-type PageInfo {
-  # When paginating forwards, the cursor to continue.
-  endCursor: String
-
-  # When paginating forwards, are there more items?
-  hasNextPage: Boolean!
-
-  # When paginating backwards, are there more items?
-  hasPreviousPage: Boolean!
-
-  # When paginating backwards, the cursor to continue.
-  startCursor: String
-}
-
-type PublicKey implements Node {
-  # The ID of the object
+type InterfaceVersion implements Node {
+  """The ID of the object"""
   id: ID!
-  key: String!
-  keyId: String!
-  owner: User!
-  revoked: Boolean!
-  revokedAt: DateTime
-  uploadedAt: DateTime!
-  verifyingSignature: Signature
-}
-
-input PublishPackageInput {
-  clientMutationId: String
-  description: String!
-  file: String
-  homepage: String
-
-  # The package icon
-  icon: String
-  license: String
-  licenseFile: String
-  manifest: String!
-  name: String!
-  readme: String
-  repository: String
-  signature: InputSignature
+  interface: Interface!
   version: String!
+  content: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  publishedBy: User!
+  packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
 }
 
-type PublishPackagePayload {
-  clientMutationId: String
-  packageVersion: PackageVersion!
-  success: Boolean!
+type Interface implements Node {
+  """The ID of the object"""
+  id: ID!
+  name: String!
+  displayName: String!
+  description: String!
+  homepage: String
+  icon: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  versions(offset: Int, before: String, after: String, first: Int, last: Int): InterfaceVersionConnection!
+  lastVersion: InterfaceVersion
 }
 
-input PublishPublicKeyInput {
-  clientMutationId: String
-  key: String!
-  keyId: String!
-  verifyingSignatureId: String
+type InterfaceVersionConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [InterfaceVersionEdge]!
 }
 
-type PublishPublicKeyPayload {
-  clientMutationId: String
-  publicKey: PublicKey!
-  success: Boolean!
+"""A Relay edge containing a `InterfaceVersion` and its cursor."""
+type InterfaceVersionEdge {
+  """The item at the end of the edge"""
+  node: InterfaceVersion
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
-type Query {
-  getCommand(name: String!): Command
-  getCommands(names: [String!]!): [Command]
-  getContract(name: String!): Interface @deprecated(reason: "Please use getInterface instead")
-  getContractVersion(name: String!, version: String = null): InterfaceVersion @deprecated(reason: "Please use getInterfaceVersion instead")
-  getContracts(names: [String!]!): [Interface]! @deprecated(reason: "Please use getInterfaces instead")
-  getGlobalObject(slug: String!): GlobalObject
-  getInterface(name: String!): Interface
-  getInterfaceVersion(name: String!, version: String = "latest"): InterfaceVersion
-  getInterfaces(names: [String!]!): [Interface]!
-  getNamespace(name: String!): Namespace
-  getPackage(name: String!): Package
-  getPackageVersion(name: String!, version: String = "latest"): PackageVersion
-  getPackageVersions(names: [String!]!): [PackageVersion]
-  getPackages(names: [String!]!): [Package]!
-  getPasswordResetToken(token: String!): GetPasswordResetToken
-  getUser(username: String!): User
-  node(
-    # The ID of the object
-    id: ID!
-  ): Node
-  packages(after: String = null, before: String = null, first: Int = null, last: Int = null): PackageConnection
-  recentPackageVersions(after: String = null, before: String = null, curated: Boolean = null, first: Int = null, last: Int = null, offset: Int = null): PackageVersionConnection
-  search(after: String = null, before: String = null, curated: Boolean = null, first: Int = null, hasBindings: Boolean = null, isStandalone: Boolean = null, kind: [SearchKind!] = null, last: Int = null, orderBy: SearchOrderBy = null, publishDate: SearchPublishDate = null, query: String!, sort: SearchOrderSort = null, withInterfaces: [String!] = null): SearchConnection!
-  searchAutocomplete(after: String = null, before: String = null, first: Int = null, kind: [SearchKind!] = null, last: Int = null, query: String!): SearchConnection!
-  viewer: User
+type PackageVersionConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageVersionEdge]!
 }
 
-input ReadNotificationInput {
-  clientMutationId: String
-  notificationId: ID!
+"""A Relay edge containing a `PackageVersion` and its cursor."""
+type PackageVersionEdge {
+  """The item at the end of the edge"""
+  node: PackageVersion
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
-type ReadNotificationPayload {
-  clientMutationId: String
-  notification: UserNotification
+union PiritaFilesystemItem = PiritaFilesystemFile | PiritaFilesystemDir
+
+type PiritaFilesystemFile {
+  name(display: PiritaFilesystemNameDisplay): String!
+  size: Int!
+  offset: Int!
 }
 
-input RefreshInput {
-  clientMutationId: String
-  refreshToken: String
+enum PiritaFilesystemNameDisplay {
+  RELATIVE
+  ABSOLUTE
 }
 
-type RefreshPayload {
-  clientMutationId: String
-  payload: GenericScalar!
-  refreshExpiresIn: Int!
-  refreshToken: String!
-  token: String!
+type PiritaFilesystemDir {
+  name(display: PiritaFilesystemNameDisplay): String!
 }
 
-input RegisterUserInput {
-  clientMutationId: String
-  email: String!
-  fullName: String!
-  password: String!
-  username: String!
+type Collection {
+  slug: String!
+  displayName: String!
+  description: String!
+  createdAt: DateTime!
+  banner: String!
+  packages(before: String, after: String, first: Int, last: Int): PackageConnection!
 }
 
-type RegisterUserPayload {
-  clientMutationId: String
-  token: String
+type PackageCollaboratorConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageCollaboratorEdge]!
 }
 
-# An enumeration.
-enum RegistryNamespaceMaintainerInviteRoleChoices {
-  # Admin
-  ADMIN
+"""A Relay edge containing a `PackageCollaborator` and its cursor."""
+type PackageCollaboratorEdge {
+  """The item at the end of the edge"""
+  node: PackageCollaborator
 
-  # Editor
-  EDITOR
-
-  # Viewer
-  VIEWER
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
-# An enumeration.
-enum RegistryNamespaceMaintainerRoleChoices {
-  # Admin
-  ADMIN
-
-  # Editor
-  EDITOR
-
-  # Viewer
-  VIEWER
+type PackageCollaborator implements Node {
+  """The ID of the object"""
+  id: ID!
+  user: User!
+  role: RegistryPackageMaintainerRoleChoices!
+  package: Package!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  invite: PackageCollaboratorInvite
 }
 
-# An enumeration.
-enum RegistryPackageMaintainerInviteRoleChoices {
-  # Admin
-  ADMIN
-
-  # Editor
-  EDITOR
-
-  # Viewer
-  VIEWER
-}
-
-# An enumeration.
+"""An enumeration."""
 enum RegistryPackageMaintainerRoleChoices {
-  # Admin
+  """Admin"""
   ADMIN
 
-  # Editor
+  """Editor"""
   EDITOR
 
-  # Viewer
+  """Viewer"""
   VIEWER
 }
 
-input RemoveNamespaceCollaboratorInput {
-  clientMutationId: String
-  namespaceCollaboratorId: ID!
-}
-
-input RemoveNamespaceCollaboratorInviteInput {
-  clientMutationId: String
-  inviteId: ID!
-}
-
-type RemoveNamespaceCollaboratorInvitePayload {
-  clientMutationId: String
-  namespace: Namespace!
-}
-
-type RemoveNamespaceCollaboratorPayload {
-  clientMutationId: String
-  namespace: Namespace!
-}
-
-input RemovePackageCollaboratorInput {
-  clientMutationId: String
-  packageCollaboratorId: ID!
-}
-
-input RemovePackageCollaboratorInviteInput {
-  clientMutationId: String
-  inviteId: ID!
-}
-
-type RemovePackageCollaboratorInvitePayload {
-  clientMutationId: String
-  package: Package!
-}
-
-type RemovePackageCollaboratorPayload {
-  clientMutationId: String
-  package: Package!
-}
-
-input RemovePackageTransferRequestInput {
-  clientMutationId: String
-  packageTransferRequestId: ID!
-}
-
-type RemovePackageTransferRequestPayload {
-  clientMutationId: String
-  package: Package!
-}
-
-input RequestPackageTransferInput {
-  clientMutationId: String
-  newOwnerId: ID!
-  packageId: ID!
-}
-
-type RequestPackageTransferPayload {
-  clientMutationId: String
-  package: Package!
-}
-
-input RequestPasswordResetInput {
-  clientMutationId: String
-  email: String!
-}
-
-type RequestPasswordResetPayload {
-  clientMutationId: String
-  email: String!
-  errors: [ErrorType]
-}
-
-input RequestValidationEmailInput {
-  clientMutationId: String
-
-  # The user id
-  userId: ID
-}
-
-type RequestValidationEmailPayload {
-  clientMutationId: String
-  success: Boolean!
+type PackageCollaboratorInvite implements Node {
+  """The ID of the object"""
+  id: ID!
+  requestedBy: User!
   user: User
+  inviteEmail: String
+  package: Package!
+  role: RegistryPackageMaintainerInviteRoleChoices!
+  accepted: PackageCollaborator
+  approvedBy: User
+  declinedBy: User
+  createdAt: DateTime!
+  expiresAt: DateTime!
+  closedAt: DateTime
 }
 
-input RevokeAPITokenInput {
-  clientMutationId: String
+"""An enumeration."""
+enum RegistryPackageMaintainerInviteRoleChoices {
+  """Admin"""
+  ADMIN
 
-  # The API token ID
-  tokenId: ID!
+  """Editor"""
+  EDITOR
+
+  """Viewer"""
+  VIEWER
 }
 
-type RevokeAPITokenPayload {
-  clientMutationId: String
-  success: Boolean
-  token: APIToken
+type PackageCollaboratorInviteConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageCollaboratorInviteEdge]!
+}
+
+"""A Relay edge containing a `PackageCollaboratorInvite` and its cursor."""
+type PackageCollaboratorInviteEdge {
+  """The item at the end of the edge"""
+  node: PackageCollaboratorInvite
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
 enum Role {
@@ -1044,34 +689,221 @@ enum Role {
   VIEWER
 }
 
-type SearchConnection {
-  # Contains the nodes in this connection.
-  edges: [SearchEdge]!
+type PackageTransferRequest implements Node {
+  """The ID of the object"""
+  id: ID!
+  requestedBy: User!
+  previousOwnerObjectId: Int!
+  newOwnerObjectId: Int!
+  package: Package!
+  approvedBy: User
+  declinedBy: User
+  createdAt: DateTime!
+  expiresAt: DateTime!
+  closedAt: DateTime
+  previousOwner: PackageOwner!
+  newOwner: PackageOwner!
+}
 
-  # Pagination data for this connection.
+type NamespaceCollaboratorConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [NamespaceCollaboratorEdge]!
 }
 
-# A Relay edge containing a `Search` and its cursor.
-type SearchEdge {
-  # A cursor for use in pagination
+"""A Relay edge containing a `NamespaceCollaborator` and its cursor."""
+type NamespaceCollaboratorEdge {
+  """The item at the end of the edge"""
+  node: NamespaceCollaborator
+
+  """A cursor for use in pagination"""
   cursor: String!
+}
 
-  # The item at the end of the edge
+type PackageTransferRequestConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageTransferRequestEdge]!
+}
+
+"""A Relay edge containing a `PackageTransferRequest` and its cursor."""
+type PackageTransferRequestEdge {
+  """The item at the end of the edge"""
+  node: PackageTransferRequest
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type APITokenConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [APITokenEdge]!
+}
+
+"""A Relay edge containing a `APIToken` and its cursor."""
+type APITokenEdge {
+  """The item at the end of the edge"""
+  node: APIToken
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type APIToken {
+  id: ID!
+  user: User!
+  identifier: String
+  createdAt: DateTime!
+  revokedAt: DateTime
+  lastUsedAt: DateTime
+}
+
+type UserNotificationConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [UserNotificationEdge]!
+  hasPendingNotifications: Boolean!
+}
+
+"""A Relay edge containing a `UserNotification` and its cursor."""
+type UserNotificationEdge {
+  """The item at the end of the edge"""
+  node: UserNotification
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type UserNotification implements Node {
+  """The ID of the object"""
+  id: ID!
+  icon: String
+  body: UserNotificationBody!
+  seenState: UserNotificationSeenState!
+  kind: UserNotificationKind
+  createdAt: DateTime!
+}
+
+type UserNotificationBody {
+  text: String!
+  ranges: [NodeBodyRange]!
+}
+
+enum UserNotificationSeenState {
+  UNSEEN
+  SEEN
+  SEEN_AND_READ
+}
+
+union UserNotificationKind = UserNotificationKindPublishedPackageVersion | UserNotificationKindIncomingPackageTransfer | UserNotificationKindIncomingPackageInvite | UserNotificationKindIncomingNamespaceInvite
+
+type UserNotificationKindPublishedPackageVersion {
+  packageVersion: PackageVersion!
+}
+
+type UserNotificationKindIncomingNamespaceInvite {
+  namespaceInvite: NamespaceCollaboratorInvite!
+}
+
+type Signature {
+  id: ID!
+  publicKey: PublicKey!
+  data: String!
+  createdAt: DateTime!
+}
+
+type UserNotificationKindIncomingPackageTransfer {
+  packageTransferRequest: PackageTransferRequest!
+}
+
+type UserNotificationKindIncomingPackageInvite {
+  packageInvite: PackageCollaboratorInvite!
+}
+
+type Query {
+  viewer: User
+  getUser(username: String!): User
+  getPasswordResetToken(token: String!): GetPasswordResetToken
+  packages(before: String, after: String, first: Int, last: Int): PackageConnection
+  recentPackageVersions(curated: Boolean, offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+  getNamespace(name: String!): Namespace
+  getPackage(name: String!): Package
+  getPackages(names: [String!]!): [Package]!
+  getPackageVersion(name: String!, version: String = "latest"): PackageVersion
+  getPackageVersions(names: [String!]!): [PackageVersion]
+  getInterface(name: String!): Interface
+  getInterfaces(names: [String!]!): [Interface]!
+  getInterfaceVersion(name: String!, version: String = "latest"): InterfaceVersion
+  getContract(name: String!): Interface @deprecated(reason: "Please use getInterface instead")
+  getContracts(names: [String!]!): [Interface]! @deprecated(reason: "Please use getInterfaces instead")
+  getContractVersion(name: String!, version: String): InterfaceVersion @deprecated(reason: "Please use getInterfaceVersion instead")
+  getCommand(name: String!): Command
+  getCommands(names: [String!]!): [Command]
+  getCollections(before: String, after: String, first: Int, last: Int): CollectionConnection
+  search(query: String!, curated: Boolean, orderBy: SearchOrderBy, sort: SearchOrderSort, kind: [SearchKind!], publishDate: SearchPublishDate, hasBindings: Boolean, isStandalone: Boolean, withInterfaces: [String!], before: String, after: String, first: Int, last: Int): SearchConnection!
+  searchAutocomplete(kind: [SearchKind!], query: String!, before: String, after: String, first: Int, last: Int): SearchConnection!
+  getGlobalObject(slug: String!): GlobalObject
+  node(
+    """The ID of the object"""
+    id: ID!
+  ): Node
+}
+
+type GetPasswordResetToken {
+  valid: Boolean!
+  user: User
+}
+
+type CollectionConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [CollectionEdge]!
+}
+
+"""A Relay edge containing a `Collection` and its cursor."""
+type CollectionEdge {
+  """The item at the end of the edge"""
+  node: Collection
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type SearchConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [SearchEdge]!
+}
+
+"""A Relay edge containing a `Search` and its cursor."""
+type SearchEdge {
+  """The item at the end of the edge"""
   node: SearchResult
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
-enum SearchKind {
-  NAMESPACE
-  PACKAGE
-  USER
-}
+union SearchResult = PackageVersion | User | Namespace
 
 enum SearchOrderBy {
   ALPHABETICALLY
-  PUBLISHED_DATE
   SIZE
   TOTAL_DOWNLOADS
+  PUBLISHED_DATE
 }
 
 enum SearchOrderSort {
@@ -1079,318 +911,642 @@ enum SearchOrderSort {
   DESC
 }
 
+enum SearchKind {
+  PACKAGE
+  NAMESPACE
+  USER
+}
+
 enum SearchPublishDate {
   LAST_DAY
-  LAST_MONTH
   LAST_WEEK
+  LAST_MONTH
   LAST_YEAR
 }
 
-union SearchResult = Namespace | PackageVersion | User
+union GlobalObject = User | Namespace
+
+type Mutation {
+  tokenAuth(input: ObtainJSONWebTokenInput!): ObtainJSONWebTokenPayload
+  registerUser(input: RegisterUserInput!): RegisterUserPayload
+  socialAuth(input: SocialAuthJWTInput!): SocialAuthJWTPayload
+  validateUserEmail(input: ValidateUserEmailInput!): ValidateUserEmailPayload
+  requestPasswordReset(input: RequestPasswordResetInput!): RequestPasswordResetPayload
+  requestValidationEmail(input: RequestValidationEmailInput!): RequestValidationEmailPayload
+  changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordPayload
+  changeUserUsername(input: ChangeUserUsernameInput!): ChangeUserUsernamePayload
+  changeUserEmail(input: ChangeUserEmailInput!): ChangeUserEmailPayload
+  updateUserInfo(input: UpdateUserInfoInput!): UpdateUserInfoPayload
+  validateUserPassword(input: ValidateUserPasswordInput!): ValidateUserPasswordPayload
+  generateApiToken(input: GenerateAPITokenInput!): GenerateAPITokenPayload
+  revokeApiToken(input: RevokeAPITokenInput!): RevokeAPITokenPayload
+  checkUserExists(input: CheckUserExistsInput!): CheckUserExistsPayload
+  readNotification(input: ReadNotificationInput!): ReadNotificationPayload
+  seePendingNotifications(input: SeePendingNotificationsInput!): SeePendingNotificationsPayload
+  publishPublicKey(input: PublishPublicKeyInput!): PublishPublicKeyPayload
+  publishPackage(input: PublishPackageInput!): PublishPackagePayload
+  updatePackage(input: UpdatePackageInput!): UpdatePackagePayload
+  likePackage(input: LikePackageInput!): LikePackagePayload
+  unlikePackage(input: UnlikePackageInput!): UnlikePackagePayload
+  watchPackage(input: WatchPackageInput!): WatchPackagePayload
+  unwatchPackage(input: UnwatchPackageInput!): UnwatchPackagePayload
+  archivePackage(input: ArchivePackageInput!): ArchivePackagePayload
+  changePackageVersionArchivedStatus(input: ChangePackageVersionArchivedStatusInput!): ChangePackageVersionArchivedStatusPayload
+  createNamespace(input: CreateNamespaceInput!): CreateNamespacePayload
+  updateNamespace(input: UpdateNamespaceInput!): UpdateNamespacePayload
+  deleteNamespace(input: DeleteNamespaceInput!): DeleteNamespacePayload
+  inviteNamespaceCollaborator(input: InviteNamespaceCollaboratorInput!): InviteNamespaceCollaboratorPayload
+  acceptNamespaceCollaboratorInvite(input: AcceptNamespaceCollaboratorInviteInput!): AcceptNamespaceCollaboratorInvitePayload
+  removeNamespaceCollaboratorInvite(input: RemoveNamespaceCollaboratorInviteInput!): RemoveNamespaceCollaboratorInvitePayload
+  removeNamespaceCollaborator(input: RemoveNamespaceCollaboratorInput!): RemoveNamespaceCollaboratorPayload
+  updateNamespaceCollaboratorRole(input: UpdateNamespaceCollaboratorRoleInput!): UpdateNamespaceCollaboratorRolePayload
+  updateNamespaceCollaboratorInviteRole(input: UpdateNamespaceCollaboratorInviteRoleInput!): UpdateNamespaceCollaboratorInviteRolePayload
+  invitePackageCollaborator(input: InvitePackageCollaboratorInput!): InvitePackageCollaboratorPayload
+  acceptPackageCollaboratorInvite(input: AcceptPackageCollaboratorInviteInput!): AcceptPackageCollaboratorInvitePayload
+  removePackageCollaboratorInvite(input: RemovePackageCollaboratorInviteInput!): RemovePackageCollaboratorInvitePayload
+  updatePackageCollaboratorRole(input: UpdatePackageCollaboratorRoleInput!): UpdatePackageCollaboratorRolePayload
+  updatePackageCollaboratorInviteRole(input: UpdatePackageCollaboratorInviteRoleInput!): UpdatePackageCollaboratorInviteRolePayload
+  removePackageCollaborator(input: RemovePackageCollaboratorInput!): RemovePackageCollaboratorPayload
+  requestPackageTransfer(input: RequestPackageTransferInput!): RequestPackageTransferPayload
+  acceptPackageTransferRequest(input: AcceptPackageTransferRequestInput!): AcceptPackageTransferRequestPayload
+  removePackageTransferRequest(input: RemovePackageTransferRequestInput!): RemovePackageTransferRequestPayload
+}
+
+type ObtainJSONWebTokenPayload {
+  payload: GenericScalar!
+  refreshExpiresIn: Int!
+  clientMutationId: String
+  token: String!
+  refreshToken: String!
+}
+
+"""
+The `GenericScalar` scalar type represents a generic
+GraphQL scalar value that could be:
+String, Boolean, Int, Float, List or Object.
+"""
+scalar GenericScalar
+
+input ObtainJSONWebTokenInput {
+  clientMutationId: String
+  username: String!
+  password: String!
+}
+
+type RegisterUserPayload {
+  token: String
+  clientMutationId: String
+}
+
+input RegisterUserInput {
+  fullName: String!
+  email: String!
+  username: String!
+  password: String!
+  clientMutationId: String
+}
+
+type SocialAuthJWTPayload {
+  social: SocialAuth
+  token: String
+  clientMutationId: String
+}
+
+type SocialAuth implements Node {
+  """The ID of the object"""
+  id: ID!
+  user: User!
+  provider: String!
+  uid: String!
+  extraData: String!
+  created: DateTime!
+  modified: DateTime!
+}
+
+input SocialAuthJWTInput {
+  provider: String!
+  accessToken: String!
+  clientMutationId: String
+}
+
+type ValidateUserEmailPayload {
+  user: User
+  clientMutationId: String
+}
+
+input ValidateUserEmailInput {
+  """The user id"""
+  userId: ID
+  challenge: String!
+  clientMutationId: String
+}
+
+type RequestPasswordResetPayload {
+  email: String!
+  errors: [ErrorType]
+  clientMutationId: String
+}
+
+type ErrorType {
+  field: String!
+  messages: [String!]!
+}
+
+input RequestPasswordResetInput {
+  email: String!
+  clientMutationId: String
+}
+
+type RequestValidationEmailPayload {
+  user: User
+  success: Boolean!
+  clientMutationId: String
+}
+
+input RequestValidationEmailInput {
+  """The user id"""
+  userId: ID
+  clientMutationId: String
+}
+
+type ChangeUserPasswordPayload {
+  token: String
+  clientMutationId: String
+}
+
+input ChangeUserPasswordInput {
+  """
+  The token associated to change the password. If not existing it will use the request user by default
+  """
+  token: String
+  oldPassword: String
+  password: String!
+  clientMutationId: String
+}
+
+type ChangeUserUsernamePayload {
+  user: User
+  token: String
+  clientMutationId: String
+}
+
+input ChangeUserUsernameInput {
+  """The new user username"""
+  username: String!
+  clientMutationId: String
+}
+
+type ChangeUserEmailPayload {
+  user: User!
+  clientMutationId: String
+}
+
+input ChangeUserEmailInput {
+  newEmail: String!
+  clientMutationId: String
+}
+
+type UpdateUserInfoPayload {
+  user: User
+  clientMutationId: String
+}
+
+input UpdateUserInfoInput {
+  """The user id"""
+  userId: ID
+
+  """The user full name"""
+  fullName: String
+
+  """The user bio"""
+  bio: String
+
+  """The user avatar"""
+  avatar: String
+
+  """
+  The user Twitter (it can be the url, or the handle with or without the @)
+  """
+  twitter: String
+
+  """
+  The user Github (it can be the url, or the handle with or without the @)
+  """
+  github: String
+
+  """The user website (it must be a valid url)"""
+  websiteUrl: String
+
+  """The user location"""
+  location: String
+  clientMutationId: String
+}
+
+type ValidateUserPasswordPayload {
+  success: Boolean
+  clientMutationId: String
+}
+
+input ValidateUserPasswordInput {
+  password: String!
+  clientMutationId: String
+}
+
+type GenerateAPITokenPayload {
+  token: APIToken
+  tokenRaw: String
+  user: User
+  clientMutationId: String
+}
+
+input GenerateAPITokenInput {
+  identifier: String
+  clientMutationId: String
+}
+
+type RevokeAPITokenPayload {
+  token: APIToken
+  success: Boolean
+  clientMutationId: String
+}
+
+input RevokeAPITokenInput {
+  """The API token ID"""
+  tokenId: ID!
+  clientMutationId: String
+}
+
+type CheckUserExistsPayload {
+  exists: Boolean!
+
+  """The user is only returned if the user input was the username"""
+  user: User
+  clientMutationId: String
+}
+
+input CheckUserExistsInput {
+  """The user"""
+  user: String!
+  clientMutationId: String
+}
+
+type ReadNotificationPayload {
+  notification: UserNotification
+  clientMutationId: String
+}
+
+input ReadNotificationInput {
+  notificationId: ID!
+  clientMutationId: String
+}
+
+type SeePendingNotificationsPayload {
+  success: Boolean
+  clientMutationId: String
+}
 
 input SeePendingNotificationsInput {
   clientMutationId: String
 }
 
-type SeePendingNotificationsPayload {
-  clientMutationId: String
-  success: Boolean
-}
-
-type Signature {
-  createdAt: DateTime!
-  data: String!
-  id: ID!
+type PublishPublicKeyPayload {
+  success: Boolean!
   publicKey: PublicKey!
-}
-
-input SocialAuthJWTInput {
-  accessToken: String!
   clientMutationId: String
-  provider: String!
 }
 
-# Social Auth for JSON Web Token (JWT)
-type SocialAuthJWTPayload {
+input PublishPublicKeyInput {
+  keyId: String!
+  key: String!
+  verifyingSignatureId: String
   clientMutationId: String
-  social: SocialNode
-  token: String
 }
 
-scalar SocialCamelJSON
-
-type SocialNode implements Node {
-  created: DateTime!
-  extraData: SocialCamelJSON
-
-  # The ID of the object
-  id: ID!
-  modified: DateTime!
-  provider: String!
-  uid: String!
-  user: User!
-}
-
-type Subscription {
-  packageVersionCreated(ownerId: ID = null, publishedBy: ID = null): PackageVersion!
-  userNotificationCreated(userId: ID!): UserNotificationCreated!
-}
-
-input UnlikePackageInput {
+type PublishPackagePayload {
+  success: Boolean!
+  packageVersion: PackageVersion!
   clientMutationId: String
-  packageId: ID!
 }
 
-type UnlikePackagePayload {
-  clientMutationId: String
-  package: Package!
-}
+input PublishPackageInput {
+  name: String!
+  version: String!
+  description: String!
+  manifest: String!
+  license: String
+  licenseFile: String
+  readme: String
+  repository: String
+  homepage: String
+  file: String
+  signature: InputSignature
 
-input UnwatchPackageInput {
-  clientMutationId: String
-  packageId: ID!
-}
-
-type UnwatchPackagePayload {
-  clientMutationId: String
-  package: Package!
-}
-
-input UpdateNamespaceCollaboratorRoleInput {
-  clientMutationId: String
-  namespaceCollaboratorId: ID!
-  role: Role!
-}
-
-type UpdateNamespaceCollaboratorRolePayload {
-  clientMutationId: String
-  collaborator: NamespaceCollaborator!
-}
-
-input UpdateNamespaceInput {
-  # The namespace avatar
-  avatar: String
-  clientMutationId: String
-
-  # The namespace description
-  description: String
-
-  # The namespace display name
-  displayName: String
-
-  # The namespace slug name
-  name: String
-  namespaceId: ID!
-}
-
-type UpdateNamespacePayload {
-  clientMutationId: String
-  namespace: Namespace!
-}
-
-input UpdatePackageCollaboratorRoleInput {
-  clientMutationId: String
-  packageCollaboratorId: ID!
-  role: Role!
-}
-
-type UpdatePackageCollaboratorRolePayload {
-  clientMutationId: String
-  collaborator: PackageCollaborator!
-}
-
-input UpdatePackageInput {
-  clientMutationId: String
-
-  # The package icon
+  """The package icon"""
   icon: String
-  packageId: ID!
+  clientMutationId: String
+}
+
+input InputSignature {
+  publicKeyKeyId: String!
+  data: String!
 }
 
 type UpdatePackagePayload {
-  clientMutationId: String
   package: Package!
-}
-
-input UpdateUserInfoInput {
-  # The user avatar
-  avatar: String
-
-  # The user bio
-  bio: String
   clientMutationId: String
-
-  # The user full name
-  fullName: String
-
-  # The user Github (it can be the url, or the handle with or without the @)
-  github: String
-
-  # The user location
-  location: String
-
-  # The user Twitter (it can be the url, or the handle with or without the @)
-  twitter: String
-
-  # The user id
-  userId: ID
-
-  # The user website (it must be a valid url)
-  websiteUrl: String
 }
 
-type UpdateUserInfoPayload {
-  clientMutationId: String
-  user: User
-}
+input UpdatePackageInput {
+  packageId: ID!
 
-type User implements Node & PackageOwner {
-  apiTokens(after: String = null, before: String = null, first: Int = null, last: Int = null): APITokenConnection
-  avatar(size: Int = 80): String!
-  bio: String
-  dateJoined: DateTime!
-  email: String!
-  firstName: String!
-  fullName: String!
-  githubUrl: String
-  globalName: String!
-
-  # The ID of the object
-  id: ID!
-  isEmailValidated: Boolean!
-  isViewer: Boolean!
-  lastName: String!
-  location: String
-  namespaceInvitesIncoming(after: String = null, before: String = null, first: Int = null, last: Int = null): NamespaceCollaboratorInviteConnection
-  namespaces(after: String = null, before: String = null, first: Int = null, last: Int = null): NamespaceConnection
-  notifications(after: String = null, before: String = null, first: Int = null, last: Int = null): UserNotificationConnection
-  packageInvitesIncoming(after: String = null, before: String = null, first: Int = null, last: Int = null): PackageCollaboratorInviteConnection
-  packageTransfersIncoming(after: String = null, before: String = null, first: Int = null, last: Int = null): PackageTransferRequestConnection
-  packageVersions(after: String = null, before: String = null, first: Int = null, last: Int = null): PackageVersionConnection
-  packages(after: String = null, before: String = null, collaborating: Boolean = null, first: Int = null, last: Int = null): PackageConnection
-  publicActivity(after: String = null, before: String = null, first: Int = null, last: Int = null): ActivityEventConnection!
-  twitterUrl: String
-
-  # Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.
-  username: String!
-  websiteUrl: String
-}
-
-type UserConnection {
-  # Contains the nodes in this connection.
-  edges: [UserEdge]!
-
-  # Pagination data for this connection.
-  pageInfo: PageInfo!
-}
-
-# A Relay edge containing a `User` and its cursor.
-type UserEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: User
-}
-
-type UserNotification implements Node {
-  body: UserNotificationBody!
-  createdAt: DateTime!
+  """The package icon"""
   icon: String
-
-  # The ID of the object
-  id: ID!
-  kind: UserNotificationKind
-  seenState: UserNotificationSeenState!
+  clientMutationId: String
 }
 
-type UserNotificationBody {
-  ranges: [NodeBodyRange]!
-  text: String!
+type LikePackagePayload {
+  package: Package!
+  clientMutationId: String
 }
 
-type UserNotificationConnection {
-  # Contains the nodes in this connection.
-  edges: [UserNotificationEdge]!
-  hasPendingNotifications: Boolean!
+input LikePackageInput {
+  packageId: ID!
+  clientMutationId: String
+}
 
-  # Pagination data for this connection.
-  pageInfo: PageInfo!
+type UnlikePackagePayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input UnlikePackageInput {
+  packageId: ID!
+  clientMutationId: String
+}
+
+type WatchPackagePayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input WatchPackageInput {
+  packageId: ID!
+  clientMutationId: String
+}
+
+type UnwatchPackagePayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input UnwatchPackageInput {
+  packageId: ID!
+  clientMutationId: String
+}
+
+type ArchivePackagePayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input ArchivePackageInput {
+  packageId: ID!
+  clientMutationId: String
+}
+
+type ChangePackageVersionArchivedStatusPayload {
+  packageVersion: PackageVersion!
+  clientMutationId: String
+}
+
+input ChangePackageVersionArchivedStatusInput {
+  packageVersionId: ID!
+  isArchived: Boolean
+  clientMutationId: String
+}
+
+type CreateNamespacePayload {
+  namespace: Namespace!
+  user: User!
+  clientMutationId: String
+}
+
+input CreateNamespaceInput {
+  name: String!
+
+  """The namespace display name"""
+  displayName: String
+
+  """The namespace description"""
+  description: String
+
+  """The namespace avatar"""
+  avatar: String
+  clientMutationId: String
+}
+
+type UpdateNamespacePayload {
+  namespace: Namespace!
+  clientMutationId: String
+}
+
+input UpdateNamespaceInput {
+  namespaceId: ID!
+
+  """The namespace slug name"""
+  name: String
+
+  """The namespace display name"""
+  displayName: String
+
+  """The namespace description"""
+  description: String
+
+  """The namespace avatar"""
+  avatar: String
+  clientMutationId: String
+}
+
+type DeleteNamespacePayload {
+  success: Boolean!
+  clientMutationId: String
+}
+
+input DeleteNamespaceInput {
+  namespaceId: ID!
+  clientMutationId: String
+}
+
+type InviteNamespaceCollaboratorPayload {
+  invite: NamespaceCollaboratorInvite!
+  namespace: Namespace!
+  clientMutationId: String
+}
+
+input InviteNamespaceCollaboratorInput {
+  namespaceId: ID!
+  role: Role!
+  username: String
+  email: String
+  clientMutationId: String
+}
+
+type AcceptNamespaceCollaboratorInvitePayload {
+  namespaceCollaboratorInvite: NamespaceCollaboratorInvite!
+  clientMutationId: String
+}
+
+input AcceptNamespaceCollaboratorInviteInput {
+  inviteId: ID!
+  clientMutationId: String
+}
+
+type RemoveNamespaceCollaboratorInvitePayload {
+  namespace: Namespace!
+  clientMutationId: String
+}
+
+input RemoveNamespaceCollaboratorInviteInput {
+  inviteId: ID!
+  clientMutationId: String
+}
+
+type RemoveNamespaceCollaboratorPayload {
+  namespace: Namespace!
+  clientMutationId: String
+}
+
+input RemoveNamespaceCollaboratorInput {
+  namespaceCollaboratorId: ID!
+  clientMutationId: String
+}
+
+type UpdateNamespaceCollaboratorRolePayload {
+  collaborator: NamespaceCollaborator!
+  clientMutationId: String
+}
+
+input UpdateNamespaceCollaboratorRoleInput {
+  namespaceCollaboratorId: ID!
+  role: Role!
+  clientMutationId: String
+}
+
+type UpdateNamespaceCollaboratorInviteRolePayload {
+  collaboratorInvite: NamespaceCollaboratorInvite!
+  clientMutationId: String
+}
+
+input UpdateNamespaceCollaboratorInviteRoleInput {
+  namespaceCollaboratorInviteId: ID!
+  role: Role!
+  clientMutationId: String
+}
+
+type InvitePackageCollaboratorPayload {
+  invite: PackageCollaboratorInvite!
+  package: Package!
+  clientMutationId: String
+}
+
+input InvitePackageCollaboratorInput {
+  packageName: String!
+  role: Role!
+  username: String
+  email: String
+  clientMutationId: String
+}
+
+type AcceptPackageCollaboratorInvitePayload {
+  packageCollaboratorInvite: PackageCollaboratorInvite!
+  clientMutationId: String
+}
+
+input AcceptPackageCollaboratorInviteInput {
+  inviteId: ID!
+  clientMutationId: String
+}
+
+type RemovePackageCollaboratorInvitePayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input RemovePackageCollaboratorInviteInput {
+  inviteId: ID!
+  clientMutationId: String
+}
+
+type UpdatePackageCollaboratorRolePayload {
+  collaborator: PackageCollaborator!
+  clientMutationId: String
+}
+
+input UpdatePackageCollaboratorRoleInput {
+  packageCollaboratorId: ID!
+  role: Role!
+  clientMutationId: String
+}
+
+type UpdatePackageCollaboratorInviteRolePayload {
+  collaboratorInvite: PackageCollaboratorInvite!
+  clientMutationId: String
+}
+
+input UpdatePackageCollaboratorInviteRoleInput {
+  packageCollaboratorInviteId: ID!
+  role: Role!
+  clientMutationId: String
+}
+
+type RemovePackageCollaboratorPayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input RemovePackageCollaboratorInput {
+  packageCollaboratorId: ID!
+  clientMutationId: String
+}
+
+type RequestPackageTransferPayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input RequestPackageTransferInput {
+  packageId: ID!
+  newOwnerId: ID!
+  clientMutationId: String
+}
+
+type AcceptPackageTransferRequestPayload {
+  package: Package!
+  packageTransferRequest: PackageTransferRequest!
+  clientMutationId: String
+}
+
+input AcceptPackageTransferRequestInput {
+  packageTransferRequestId: ID!
+  clientMutationId: String
+}
+
+type RemovePackageTransferRequestPayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input RemovePackageTransferRequestInput {
+  packageTransferRequestId: ID!
+  clientMutationId: String
+}
+
+type Subscription {
+  packageVersionCreated(publishedBy: ID, ownerId: ID): PackageVersion!
+  userNotificationCreated(userId: ID!): UserNotificationCreated!
 }
 
 type UserNotificationCreated {
   notification: UserNotification
   notificationDeletedId: ID
-}
-
-# A Relay edge containing a `UserNotification` and its cursor.
-type UserNotificationEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: UserNotification
-}
-
-union UserNotificationKind = UserNotificationKindIncomingPackageInvite | UserNotificationKindIncomingPackageTransfer | UserNotificationKindPublishedPackageVersion
-
-type UserNotificationKindIncomingPackageInvite {
-  packageInvite: PackageCollaboratorInvite!
-}
-
-type UserNotificationKindIncomingPackageTransfer {
-  packageTransferRequest: PackageTransferRequest!
-}
-
-type UserNotificationKindPublishedPackageVersion {
-  packageVersion: PackageVersion!
-}
-
-enum UserNotificationSeenState {
-  SEEN
-  SEEN_AND_READ
-  UNSEEN
-}
-
-input ValidateUserEmailInput {
-  challenge: String!
-  clientMutationId: String
-
-  # The user id
-  userId: ID
-}
-
-type ValidateUserEmailPayload {
-  clientMutationId: String
-  user: User
-}
-
-input ValidateUserPasswordInput {
-  clientMutationId: String
-  password: String!
-}
-
-type ValidateUserPasswordPayload {
-  clientMutationId: String
-  success: Boolean
-}
-
-input VerifyInput {
-  clientMutationId: String
-  token: String
-}
-
-type VerifyPayload {
-  clientMutationId: String
-  payload: GenericScalar!
-}
-
-input WatchPackageInput {
-  clientMutationId: String
-  packageId: ID!
-}
-
-type WatchPackagePayload {
-  clientMutationId: String
-  package: Package!
 }

--- a/src/dataflow/bindings.rs
+++ b/src/dataflow/bindings.rs
@@ -66,6 +66,7 @@ pub fn link_to_package_bindings(
         .filter_map(|bindings| match (language, bindings.on) {
             (Language::JavaScript, get_bindings_query::GetBindingsQueryPackageVersionBindingsOn::PackageVersionNPMBinding(b)) => Some((
                 bindings.module,
+                #[allow(deprecated)]
                 b.npm_default_install_package_name,
         )),
             (Language::Python, get_bindings_query::GetBindingsQueryPackageVersionBindingsOn::PackageVersionPythonBinding(b)) => Some((

--- a/src/dataflow/resolved_packages.rs
+++ b/src/dataflow/resolved_packages.rs
@@ -111,9 +111,7 @@ impl<'a> Resolve<'a> for RegistryResolver {
             .into_iter()
             .flatten()
             .map(|p| {
-                let versions = p.versions.unwrap_or_default();
-                let name = p.name;
-                (name, versions)
+                (p.name, p.versions)
             })
             .flat_map(|(n, vs)| {
                 vs.into_iter()

--- a/src/dataflow/resolved_packages.rs
+++ b/src/dataflow/resolved_packages.rs
@@ -110,9 +110,7 @@ impl<'a> Resolve<'a> for RegistryResolver {
             .package
             .into_iter()
             .flatten()
-            .map(|p| {
-                (p.name, p.versions)
-            })
+            .map(|p| (p.name, p.versions))
             .flat_map(|(n, vs)| {
                 vs.into_iter()
                     .flatten()


### PR DESCRIPTION
This adds a `make update-schema` task to the Makefile which will automatically download the latest schema from whichever registry `wapm` is currently using.

Requires https://github.com/wasmerio/wapm.io-backend/pull/241.