### PR TITLE
Temporarily disabled some regression tests

### DIFF
--- a/end-to-end-tests/direct_execute.sh
+++ b/end-to-end-tests/direct_execute.sh
@@ -4,8 +4,8 @@ export RUST_BACKTRACE=1
 ln -sf `which wapm` wax
 wapm config set registry.url "https://registry.wapm.dev"
 
-echo "hello" | wapm execute base64
-./wax echo "hello"
+# echo "hello" | wapm execute base64
+# ./wax echo "hello"
 wapm install namespace-example/cowsay
 ./wax --emscripten cowsay "hello"
 wapm uninstall namespace-example/cowsay
@@ -18,4 +18,4 @@ wapm list -a
 rm -rf $(./wax --which lolcat)/wapm_packages/_/lolcat@0.1.1/*
 ./wax lolcat -V
 ./wax --offline lolcat -V
-WAPM_RUNTIME=echo ./wax ls | grep "\-\-command-name" || echo "Success: command-name not found"
+# WAPM_RUNTIME=echo ./wax ls | grep "\-\-command-name" || echo "Success: command-name not found"

--- a/end-to-end-tests/direct_execute.txt
+++ b/end-to-end-tests/direct_execute.txt
@@ -1,7 +1,3 @@
-[INFO] Installing mark2/coreutils@0.0.3
-aGVsbG8K
-[INFO] Installing mark2/coreutils@0.0.3
-hello
 [INFO] Installing namespace-example/cowsay@0.2.0
 Package installed successfully to wapm_packages!
  _______
@@ -20,13 +16,12 @@ lolcat 1.0.1
 [INFO] Package "lolcat" is not installed.
 lolcat 1.0.1
 LOCAL PACKAGES:
- PACKAGE            | VERSION | MODULE | ABI 
- syrusakbary/lolcat | 0.1.1   | lolcat | wasi 
+ PACKAGE            | VERSION | MODULE | ABI
+ syrusakbary/lolcat | 0.1.1   | lolcat | wasi
 
 LOCAL COMMANDS:
- COMMAND | PACKAGE            | VERSION 
- lolcat  | syrusakbary/lolcat | 0.1.1 
+ COMMAND | PACKAGE            | VERSION
+ lolcat  | syrusakbary/lolcat | 0.1.1
 
 lolcat 1.0.1
 lolcat 1.0.1
-Success: command-name not found


### PR DESCRIPTION
When the [sharrattj](https://wapm.dev/sharrattj)/[coreutils](https://wapm.dev/sharrattj/coreutils) package was published, running `wapm run base64` or `wapm run echo` would use the version of `base64` and `echo` from `sharrattj/coreutils` instead of the one we've been testing with (`mark2/coreutils@0.0.3`).

Also, at some point it looks like the `mark2/coreutils` package has been removed from wapm.dev and wapm.io.