### PR TITLE
Updating "wapm install" to use the new bindings query

### DIFF
--- a/graphql/queries/get_bindings.graphql
+++ b/graphql/queries/get_bindings.graphql
@@ -2,15 +2,10 @@ query GetBindingsQuery ($name: String!, $version: String = "latest") {
   packageVersion: getPackageVersion(name:$name, version:$version) {
     version
     bindings {
-      module
-        __typename
-
-      ... on PackageVersionNPMBinding {
-        npmDefaultInstallPackageName
-      }
-      ... on PackageVersionPythonBinding {
-        pythonDefaultInstallPackageName
-      }
+      id
+      language
+      url
+      __typename
     }
   }
 }


### PR DESCRIPTION
Resolves #285. 

This should probably depend on https://github.com/wasmerio/wapm.io-backend/issues/256 because bindings aren't being generated correctly by WAPM's backend at the moment. Trying to test this PR will almost always fail with `Error: The wasmer/wit-pack-cli package doesn't contain any bindings`.