### PR TITLE
Fix release on linux

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -167,6 +167,10 @@ jobs:
       - name: Release to crates.io
         if: (needs.setup.outputs.DOING_RELEASE == '1' || github.event.inputs.release != '') && matrix.os == 'ubuntu-latest'
         run: |
+          cargo publish --allow-dirty --manifest-path="wapm-toml/Cargo.toml" --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Release to crates.io
+        if: (needs.setup.outputs.DOING_RELEASE == '1' || github.event.inputs.release != '') && matrix.os == 'ubuntu-latest'
+        run: |
           cargo publish --allow-dirty --token ${{ secrets.CRATES_IO_TOKEN }}
 
   regression_tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "wapm-toml"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "semver 1.0.13",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "wapm-toml"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "semver 1.0.13",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tempfile = "3"
 time = "0.1"
 toml = "0.5.6"
 url = "2"
-wapm-toml = { version = "0.2.1", path = "./wapm-toml" }
+wapm-toml = { version = "0.2.2", path = "./wapm-toml" }
 wasmer-wasm-interface = { version = "0.1.0", path = "lib/wasm-interface" }
 wasmparser = "0.51.4"
 dialoguer = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tempfile = "3"
 time = "0.1"
 toml = "0.5.6"
 url = "2"
-wapm-toml = { version = "0.2.0", path = "./wapm-toml" }
+wapm-toml = { version = "0.2.1", path = "./wapm-toml" }
 wasmer-wasm-interface = { version = "0.1.0", path = "lib/wasm-interface" }
 wasmparser = "0.51.4"
 dialoguer = "0.4.0"

--- a/wapm-toml/Cargo.toml
+++ b/wapm-toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wapm-toml"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Package to parse wapm.toml files from wapm.io"
 license = "MIT"

--- a/wapm-toml/Cargo.toml
+++ b/wapm-toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wapm-toml"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Package to parse wapm.toml files from wapm.io"
 license = "MIT"


### PR DESCRIPTION
Release wasn't working because we haven't incorporated wapm-toml into the release workflow